### PR TITLE
Fix double initialization causing DuckDB error

### DIFF
--- a/Views/WizardDockpaneViewModel.cs
+++ b/Views/WizardDockpaneViewModel.cs
@@ -445,7 +445,10 @@ namespace DuckDBGeoparquet.Views
             NotifyPropertyChanged(nameof(StatusText));
             _isSelectAllChecked = false; // Initialize Select All state
 
-            _ = InitializeAsync(); // This will call InitializeThemes and update release-specific paths
+            // Do not call InitializeAsync() here. The base DockPane class
+            // will invoke it automatically after construction. Calling it
+            // explicitly would cause double initialization which leads to
+            // errors such as attempting to open the DuckDB connection twice.
         }
 
         protected override async Task InitializeAsync()


### PR DESCRIPTION
## Summary
- remove redundant `InitializeAsync` call so the view model only initializes once

## Testing
- `dotnet build DuckDBGeoparquet.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849b400ef7c8325a0f52a02665aa0e9