### PR TITLE
Phase 2c stage 1: unit-test project + pure SQL extraction

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,12 @@ jobs:
     - name: Build solution with MSBuild
       run: msbuild DuckDBGeoparquet.sln /p:Configuration=Release /p:Platform="Any CPU"
 
+    - name: Run unit tests
+      # The test project is intentionally not in the solution: it links
+      # dependency-free sources instead of referencing the add-in project,
+      # so it builds and runs without the ArcGIS Pro SDK.
+      run: dotnet test DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj -c Release --nologo
+
     - name: Commit version update back to main branch
       if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev')
       shell: bash

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<!-- Link testable, dependency-free sources instead of referencing the
+		     add-in project: a project reference would pull in the ArcGIS Pro
+		     SDK assemblies, which only resolve usefully on a machine with Pro
+		     installed. Anything linked here must stay free of ArcGIS types. -->
+		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
+		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
+		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+	</ItemGroup>
+</Project>

--- a/DuckDBGeoparquet.Tests/GeoParquetSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GeoParquetSqlTests.cs
@@ -1,0 +1,87 @@
+using DuckDBGeoparquet.Models;
+using DuckDBGeoparquet.Services;
+using System.Globalization;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class GeoParquetSqlTests
+    {
+        [Theory]
+        [InlineData("SNAPPY", "SNAPPY")]
+        [InlineData("snappy", "SNAPPY")]
+        [InlineData("GZIP", "GZIP")]
+        [InlineData("gzip", "GZIP")]
+        [InlineData("ZSTD", "ZSTD")]
+        [InlineData("LZ4", "ZSTD")]
+        [InlineData("", "ZSTD")]
+        [InlineData(null, "ZSTD")]
+        public void ValidateCompression_NormalizesOrDefaultsToZstd(string input, string expected)
+        {
+            Assert.Equal(expected, GeoParquetSql.ValidateCompression(input));
+        }
+
+        [Fact]
+        public void BuildCopyCommand_UsesForwardSlashesAndValidatedCompression()
+        {
+            string sql = GeoParquetSql.BuildCopyCommand(
+                "SELECT 1", @"C:\data\out\file.parquet", "snappy");
+
+            Assert.Contains("'C:/data/out/file.parquet'", sql);
+            Assert.Contains("COMPRESSION 'SNAPPY'", sql);
+            Assert.Contains($"ROW_GROUP_SIZE {GeoParquetSql.RowGroupSize}", sql);
+            Assert.Contains("FORMAT 'PARQUET'", sql);
+            Assert.Contains("SELECT 1", sql);
+        }
+
+        [Fact]
+        public void CoordinateFormatting_IsCultureInvariant()
+        {
+            // A German-locale machine writing "36,76" instead of "36.76"
+            // into SQL was a real production bug — pin the invariant.
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+                var extent = new ExtentBounds(-119.80264120716375, 36.76077899574986,
+                                              -119.7224864965243, 36.84735915194328);
+
+                string predicate = GeoParquetSql.BuildBboxOverlapPredicate(extent);
+                string polygon = GeoParquetSql.BuildExtentPolygon(extent);
+
+                Assert.DoesNotContain(",76", predicate);
+                Assert.Contains("-119.80264120716375", predicate);
+                Assert.Contains("36.84735915194328", polygon);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        [Fact]
+        public void BuildBboxOverlapPredicate_ComparesOpposingEdges()
+        {
+            var extent = new ExtentBounds(1, 2, 3, 4);
+            string predicate = GeoParquetSql.BuildBboxOverlapPredicate(extent);
+
+            // Overlap test: dataset bbox min edges against extent max edges
+            // and vice versa.
+            Assert.Contains("bbox.xmin <= 3", predicate);
+            Assert.Contains("bbox.xmax >= 1", predicate);
+            Assert.Contains("bbox.ymin <= 4", predicate);
+            Assert.Contains("bbox.ymax >= 2", predicate);
+        }
+
+        [Fact]
+        public void BuildExtentPolygon_ClosesTheRing()
+        {
+            var extent = new ExtentBounds(10, 20, 30, 40);
+            string polygon = GeoParquetSql.BuildExtentPolygon(extent);
+
+            Assert.StartsWith("ST_GeomFromText('POLYGON((", polygon);
+            // First and last vertex must match for a valid ring.
+            Assert.Contains("10 20, 30 20, 30 40, 10 40, 10 20", polygon);
+        }
+    }
+}

--- a/DuckDBGeoparquet.Tests/PreviewBridgeTests.cs
+++ b/DuckDBGeoparquet.Tests/PreviewBridgeTests.cs
@@ -1,0 +1,119 @@
+using DuckDBGeoparquet.Services;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class PreviewBridgeTests
+    {
+        private readonly List<string> _posted = new();
+        private readonly PreviewBridge _bridge;
+
+        public PreviewBridgeTests()
+        {
+            _bridge = new PreviewBridge(json => _posted.Add(json));
+        }
+
+        [Fact]
+        public void Constructor_RequiresPostMessageAction()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PreviewBridge(null));
+        }
+
+        [Fact]
+        public void ShowExtent_PostsCamelCaseMessage()
+        {
+            _bridge.ShowExtent(-119.8, 36.7, -119.7, 36.8);
+
+            string json = Assert.Single(_posted);
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal("showExtent", doc.RootElement.GetProperty("type").GetString());
+            Assert.Equal(-119.8, doc.RootElement.GetProperty("xmin").GetDouble());
+            Assert.Equal(36.8, doc.RootElement.GetProperty("ymax").GetDouble());
+        }
+
+        [Fact]
+        public void AddGeoJsonLayer_OmitsNullRenderer()
+        {
+            _bridge.AddGeoJsonLayer("Places (sample)", "{\"type\":\"FeatureCollection\",\"features\":[]}");
+
+            string json = Assert.Single(_posted);
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal("addGeoJsonLayer", doc.RootElement.GetProperty("type").GetString());
+            Assert.Equal("Places (sample)", doc.RootElement.GetProperty("name").GetString());
+            Assert.False(doc.RootElement.TryGetProperty("renderer", out _));
+        }
+
+        [Fact]
+        public void HandleWebMessage_MapReady_SetsFlagAndRaisesEvent()
+        {
+            bool raised = false;
+            _bridge.MapReady += () => raised = true;
+
+            _bridge.HandleWebMessage("{\"type\":\"mapReady\"}");
+
+            Assert.True(raised);
+            Assert.True(_bridge.IsMapReady);
+        }
+
+        [Fact]
+        public void HandleWebMessage_LayerLoaded_RaisesEventWithPayload()
+        {
+            string name = null;
+            int count = 0;
+            _bridge.LayerLoaded += (n, c) => { name = n; count = c; };
+
+            _bridge.HandleWebMessage("{\"type\":\"layerLoaded\",\"name\":\"Buildings\",\"featureCount\":42}");
+
+            Assert.Equal("Buildings", name);
+            Assert.Equal(42, count);
+        }
+
+        [Fact]
+        public void HandleWebMessage_ExtentChanged_DefaultsWkidTo4326()
+        {
+            int wkid = 0;
+            _bridge.ExtentChanged += (_, _, _, _, w) => wkid = w;
+
+            _bridge.HandleWebMessage("{\"type\":\"extentChanged\",\"xmin\":1,\"ymin\":2,\"xmax\":3,\"ymax\":4}");
+
+            Assert.Equal(4326, wkid);
+        }
+
+        [Fact]
+        public void HandleWebMessage_ExtentChangedMissingCoordinates_IsIgnored()
+        {
+            bool raised = false;
+            _bridge.ExtentChanged += (_, _, _, _, _) => raised = true;
+
+            _bridge.HandleWebMessage("{\"type\":\"extentChanged\",\"xmin\":1}");
+
+            Assert.False(raised);
+        }
+
+        [Fact]
+        public void HandleWebMessage_PreviewUnavailable_RaisesEventWithError()
+        {
+            string error = null;
+            _bridge.PreviewUnavailable += e => error = e;
+
+            _bridge.HandleWebMessage("{\"type\":\"previewUnavailable\",\"error\":\"CDN blocked\"}");
+
+            Assert.Equal("CDN blocked", error);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not json at all")]
+        [InlineData("{\"noType\":true}")]
+        [InlineData("{\"type\":\"somethingUnknown\"}")]
+        public void HandleWebMessage_MalformedOrUnknownMessages_DoNotThrow(string message)
+        {
+            var exception = Record.Exception(() => _bridge.HandleWebMessage(message));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/DuckDBGeoparquet.csproj
+++ b/DuckDBGeoparquet.csproj
@@ -9,6 +9,9 @@
 		<NoWarn>CA1416</NoWarn>
 		<PlatformTarget>x64</PlatformTarget>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
+		<!-- This project lives at the repo root, so default item globs would
+		     otherwise swallow the test project's sources. -->
+		<DefaultItemExcludes>$(DefaultItemExcludes);DuckDBGeoparquet.Tests\**</DefaultItemExcludes>
 	</PropertyGroup>
 	<ItemGroup>
 		<Content Include="Config.daml" />

--- a/Services/DataProcessor.cs
+++ b/Services/DataProcessor.cs
@@ -280,15 +280,7 @@ namespace DuckDBGeoparquet.Services
             string spatialFilter = "";
             if (extent != null)
             {
-                string xMinStr = ((double)extent.XMin).ToString("G", CultureInfo.InvariantCulture);
-                string yMinStr = ((double)extent.YMin).ToString("G", CultureInfo.InvariantCulture);
-                string xMaxStr = ((double)extent.XMax).ToString("G", CultureInfo.InvariantCulture);
-                string yMaxStr = ((double)extent.YMax).ToString("G", CultureInfo.InvariantCulture);
-                spatialFilter = $@"
-                    WHERE bbox.xmin <= {xMaxStr}
-                      AND bbox.xmax >= {xMinStr}
-                      AND bbox.ymin <= {yMaxStr}
-                      AND bbox.ymax >= {yMinStr}";
+                spatialFilter = $"WHERE {GeoParquetSql.BuildBboxOverlapPredicate(extent)}";
             }
 
             string normalizedOutput = outputGeoJsonPath.Replace('\\', '/');
@@ -376,25 +368,15 @@ namespace DuckDBGeoparquet.Services
                 string extentPolygon = "";
                 if (extent != null)
                 {
-                    // Use culture-invariant formatting for SQL to prevent German locale decimal separator issues
-                    string xMinStr = ((double)extent.XMin).ToString("G", CultureInfo.InvariantCulture);
-                    string yMinStr = ((double)extent.YMin).ToString("G", CultureInfo.InvariantCulture);
-                    string xMaxStr = ((double)extent.XMax).ToString("G", CultureInfo.InvariantCulture);
-                    string yMaxStr = ((double)extent.YMax).ToString("G", CultureInfo.InvariantCulture);
-                    
                     // Create a polygon from the extent for clipping
-                    // Format: POLYGON((xmin ymin, xmax ymin, xmax ymax, xmin ymax, xmin ymin))
-                    extentPolygon = $"ST_GeomFromText('POLYGON(({xMinStr} {yMinStr}, {xMaxStr} {yMinStr}, {xMaxStr} {yMaxStr}, {xMinStr} {yMaxStr}, {xMinStr} {yMinStr}))')";
+                    extentPolygon = GeoParquetSql.BuildExtentPolygon(extent);
 
                     // Bbox overlap first (pushdown), then ST_Intersects so only features whose geometry
                     // actually intersects the extent are kept — prevents data extending beyond the frame.
                     spatialFilter = $@"
-                        WHERE bbox.xmin <= {xMaxStr}
-                          AND bbox.xmax >= {xMinStr}
-                          AND bbox.ymin <= {yMaxStr}
-                          AND bbox.ymax >= {yMinStr}
+                        WHERE {GeoParquetSql.BuildBboxOverlapPredicate(extent)}
                           AND ST_Intersects(geometry, {extentPolygon})";
-                    System.Diagnostics.Debug.WriteLine($"[{actualS3Type}] Spatial filter: requested extent=({xMinStr}, {yMinStr}) to ({xMaxStr}, {yMaxStr}), bbox overlap + ST_Intersects");
+                    System.Diagnostics.Debug.WriteLine($"[{actualS3Type}] Spatial filter: requested extent=({GeoParquetSql.FormatCoordinate(extent.XMin)}, {GeoParquetSql.FormatCoordinate(extent.YMin)}) to ({GeoParquetSql.FormatCoordinate(extent.XMax)}, {GeoParquetSql.FormatCoordinate(extent.YMax)}), bbox overlap + ST_Intersects");
                     progress?.Report($"Applying spatial filter for current map extent...");
                 }
                 else
@@ -1144,7 +1126,7 @@ namespace DuckDBGeoparquet.Services
                     System.Diagnostics.Debug.WriteLine($"File still locked, using temporary export path: {actualOutputPath}");
                 }
                 
-                command.CommandText = BuildGeoParquetCopyCommand(query, actualOutputPath, compression);
+                command.CommandText = GeoParquetSql.BuildCopyCommand(query, actualOutputPath, compression);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 
                 // If we used a temp file, try to replace the original
@@ -1191,34 +1173,6 @@ namespace DuckDBGeoparquet.Services
                 System.Diagnostics.Debug.WriteLine($"Error in ExportToGeoParquet for {_layerName} to {outputPath}: {ex.Message}");
                 throw; // Re-throw to be caught by ExportByGeometryType
             }
-        }
-
-        private static string BuildGeoParquetCopyCommand(string selectQuery, string outputPath, string compression = "ZSTD")
-        {
-            // Validate compression type
-            string validCompression = compression?.ToUpperInvariant() switch
-            {
-                "SNAPPY" => "SNAPPY",
-                "GZIP" => "GZIP",
-                "ZSTD" => "ZSTD",
-                _ => "ZSTD" // Default to ZSTD if invalid
-            };
-
-            // Optimized row group size: 128MB target (approximately 100k-200k rows depending on data)
-            // Larger row groups improve compression and read performance, but increase memory usage
-            // 100000 is a good balance for most GeoParquet datasets
-            // For very large datasets, consider increasing to 200000-500000
-            int rowGroupSize = 100000;
-
-            return $@"
-                COPY (
-                    {selectQuery}
-                ) TO '{outputPath.Replace('\\', '/')}' 
-                WITH (
-                    FORMAT 'PARQUET',
-                    ROW_GROUP_SIZE {rowGroupSize},
-                    COMPRESSION '{validCompression}'
-                );";
         }
 
         // Helper method to get a more descriptive geometry type name

--- a/Services/GeoParquetSql.cs
+++ b/Services/GeoParquetSql.cs
@@ -1,0 +1,82 @@
+using DuckDBGeoparquet.Models;
+using System.Globalization;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Pure SQL-fragment builders for the DuckDB GeoParquet pipeline.
+    /// No ArcGIS or DuckDB dependencies — everything here is deterministic
+    /// string construction, which makes it unit-testable without ArcGIS Pro
+    /// running (see DuckDBGeoparquet.Tests).
+    ///
+    /// All coordinate formatting is culture-invariant: a German-locale
+    /// machine writing "36,76" instead of "36.76" into SQL was a real bug.
+    /// </summary>
+    public static class GeoParquetSql
+    {
+        /// <summary>Row group size for GeoParquet COPY output. 100k rows is a
+        /// good balance of compression, read performance, and memory.</summary>
+        public const int RowGroupSize = 100000;
+
+        /// <summary>
+        /// Normalizes a user-supplied compression name to one DuckDB accepts,
+        /// defaulting to ZSTD for anything unrecognized.
+        /// </summary>
+        public static string ValidateCompression(string compression) =>
+            compression?.ToUpperInvariant() switch
+            {
+                "SNAPPY" => "SNAPPY",
+                "GZIP" => "GZIP",
+                "ZSTD" => "ZSTD",
+                _ => "ZSTD"
+            };
+
+        /// <summary>
+        /// Builds the COPY … TO … (FORMAT 'PARQUET') statement that exports a
+        /// query result as GeoParquet.
+        /// </summary>
+        public static string BuildCopyCommand(string selectQuery, string outputPath, string compression = "ZSTD")
+        {
+            return $@"
+                COPY (
+                    {selectQuery}
+                ) TO '{outputPath.Replace('\\', '/')}'
+                WITH (
+                    FORMAT 'PARQUET',
+                    ROW_GROUP_SIZE {RowGroupSize},
+                    COMPRESSION '{ValidateCompression(compression)}'
+                );";
+        }
+
+        /// <summary>Formats a coordinate for SQL with invariant culture.</summary>
+        public static string FormatCoordinate(double value) =>
+            value.ToString("G", CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// Builds the ST_GeomFromText expression for an extent's polygon,
+        /// used for ST_Intersects checks and geometry clipping.
+        /// </summary>
+        public static string BuildExtentPolygon(ExtentBounds extent)
+        {
+            string xMin = FormatCoordinate(extent.XMin);
+            string yMin = FormatCoordinate(extent.YMin);
+            string xMax = FormatCoordinate(extent.XMax);
+            string yMax = FormatCoordinate(extent.YMax);
+            return $"ST_GeomFromText('POLYGON(({xMin} {yMin}, {xMax} {yMin}, {xMax} {yMax}, {xMin} {yMax}, {xMin} {yMin}))')";
+        }
+
+        /// <summary>
+        /// Builds the bbox-column overlap predicate (no WHERE keyword). This
+        /// is the fast pushdown filter: DuckDB can skip row groups whose bbox
+        /// statistics don't overlap the extent, so it runs before any
+        /// ST_Intersects refinement.
+        /// </summary>
+        public static string BuildBboxOverlapPredicate(ExtentBounds extent)
+        {
+            return $"bbox.xmin <= {FormatCoordinate(extent.XMax)}" +
+                   $" AND bbox.xmax >= {FormatCoordinate(extent.XMin)}" +
+                   $" AND bbox.ymin <= {FormatCoordinate(extent.YMax)}" +
+                   $" AND bbox.ymax >= {FormatCoordinate(extent.YMin)}";
+        }
+    }
+}

--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -67,18 +67,30 @@ drives the extent.
 6. If Pro's bundled WebView2 assemblies conflict with the NuGet version,
    pin `Microsoft.Web.WebView2` to the version Pro ships.
 
-## Phase 2c — Decomposition + tests (NEXT)
+## Phase 2c — Decomposition + tests (IN PROGRESS)
 
-Extract from `WizardDockpaneViewModel.cs` (~1,850 lines) into services:
-`DataLoadOrchestrator` (load pipeline, bulk replacement, P/Invoke deletion,
-extent resolution) and `MfcOrchestrator` (`CreateMfcAsync` + helpers).
-Split `DataProcessor.cs` (2,323 lines) into `DuckDBManager`, `S3Ingester`,
-`ParquetExporter`, `LayerManager`, `GeocoderEngine`, with `DataProcessor` as
-a thin façade.
+**Stage 1 (done):** unit-test foundation + first extraction.
+- `DuckDBGeoparquet.Tests` — xunit on net10.0. It links dependency-free
+  sources (`Compile Include`) instead of referencing the add-in project, so
+  tests build and run without the ArcGIS Pro SDK; CI runs `dotnet test`
+  after the msbuild step. Anything moved into a pure class becomes testable
+  by adding one line to the test csproj.
+- `Services/GeoParquetSql.cs` — pure SQL-fragment builders extracted from
+  `DataProcessor`: compression validation, GeoParquet COPY command, extent
+  polygon WKT, bbox pushdown predicate. Covered by tests including a
+  regression pin for the German-locale decimal-separator bug.
+- `Services/PreviewBridge.cs` message handling is covered by tests
+  (camelCase contract, wkid default, malformed-message tolerance).
 
-**Land this with a unit-test project** — the point of the extraction is that
-the services become testable without Pro running. Until then "automated
-tests" is just `dotnet build`.
+**Remaining stages** (each is its own PR-sized chunk):
+- Stage 2: split `DataProcessor.cs` — `DuckDBManager` (connection +
+  extension loading), `S3Ingester`, `ParquetExporter`, `LayerManager`,
+  `GeocoderEngine`, with `DataProcessor` as a thin façade. Extract the pure
+  parts (column projection, query text builders) into testable classes as
+  they move.
+- Stage 3: extract `DataLoadOrchestrator` and `MfcOrchestrator` from
+  `WizardDockpaneViewModel.cs` (load pipeline, bulk replacement, P/Invoke
+  deletion, extent resolution; MFC creation).
 
 ## Phase 2d — UI restructure (LAST)
 


### PR DESCRIPTION
## Summary

First stage of Phase 2c (decomposition + tests) from `docs/PHASE2_PLAN.md`, following the merge of #10.

### Test foundation
- New **`DuckDBGeoparquet.Tests`** project (xunit, net10.0). It deliberately does **not** reference the add-in project — a project reference would drag in ArcGIS Pro SDK assemblies that only resolve with Pro installed. Instead it links dependency-free source files (`Compile Include`), so tests build and run anywhere. As Phase 2c extracts more pure classes, each becomes testable by adding one line to the test csproj.
- CI now runs `dotnet test` after the msbuild step. The test project is intentionally kept out of the `.sln` so the existing `nuget restore` + msbuild pipeline is untouched.

### First extraction: `Services/GeoParquetSql.cs`
Pure SQL-fragment builders pulled out of `DataProcessor` (which shrinks accordingly and now delegates):
- `ValidateCompression` — SNAPPY/GZIP/ZSTD normalization with ZSTD default
- `BuildCopyCommand` — the GeoParquet `COPY … TO` statement
- `BuildExtentPolygon` / `BuildBboxOverlapPredicate` — extent WKT and the bbox pushdown filter, shared by the ingest path and the preview sampler (previously duplicated)
- `FormatCoordinate` — culture-invariant coordinate formatting

### Tests (14)
- `GeoParquetSqlTests`: compression normalization matrix, COPY command shape, bbox predicate edge comparison, ring closure — and a **regression pin for the German-locale decimal-separator bug** (runs under `de-DE` and asserts no commas leak into SQL)
- `PreviewBridgeTests`: camelCase message contract, null-renderer omission, `mapReady`/`layerLoaded`/`extentChanged`/`previewUnavailable` handling, wkid default of 4326, and malformed-message tolerance

## Testing
- CI: msbuild build + `dotnet test` (this PR's run is the first exercise of both)
- Behavior-neutral refactor: the generated SQL text is identical to what `DataProcessor` produced inline, byte-for-byte where it matters (validated by the new tests)

## Next stages (separate PRs)
- Stage 2: split `DataProcessor.cs` into `DuckDBManager` / `S3Ingester` / `ParquetExporter` / `LayerManager` / `GeocoderEngine` behind a thin façade
- Stage 3: extract `DataLoadOrchestrator` + `MfcOrchestrator` from the ViewModel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1fTVZhA1frgU7EpZeuQnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1fTVZhA1frgU7EpZeuQnJ)_