### PR TITLE
Phase 2c stage 2: extract DuckDBManager from DataProcessor

### DIFF
--- a/Services/DataProcessor.cs
+++ b/Services/DataProcessor.cs
@@ -31,7 +31,12 @@ namespace DuckDBGeoparquet.Services
 
     public class DataProcessor : IDisposable
     {
-        private readonly DuckDBConnection _connection;
+        private readonly DuckDBManager _duckDb;
+
+        // Proxies keep the many existing call sites unchanged while the
+        // connection lifecycle lives in DuckDBManager (Phase 2c stage 2).
+        private DuckDBConnection _connection => _duckDb.Connection;
+        private bool _isInitialized => _duckDb.IsInitialized;
 
         // Constants
         private const string DEFAULT_SRS = "EPSG:4326";
@@ -88,7 +93,6 @@ namespace DuckDBGeoparquet.Services
         };
 
         // Add fields for state management
-        private bool _isInitialized;
         private bool _isDisposed;
 
         // Add a class-level field to store the current extent
@@ -124,7 +128,7 @@ namespace DuckDBGeoparquet.Services
 
         public DataProcessor()
         {
-            _connection = new DuckDBConnection("DataSource=:memory:");
+            _duckDb = new DuckDBManager();
             _pendingLayers = new List<LayerCreationInfo>();
         }
 
@@ -137,128 +141,8 @@ namespace DuckDBGeoparquet.Services
             _outputSessionSuffix = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture);
         }
 
-        public async Task InitializeDuckDBAsync(CancellationToken cancellationToken = default)
-        {
-            if (_isInitialized) return;
-
-            try
-            {
-                await _connection.OpenAsync();
-
-                // Get the various potential paths where extensions might be found
-                string addInFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-                string extensionsPath = Path.Combine(addInFolder, "Extensions");
-
-                using var command = _connection.CreateCommand();
-
-                try
-                {
-                    // Prefer bundled extensions when present. They load from the
-                    // add-in's own (trusted) install folder, so they work offline
-                    // and on machines where Application Control policies block
-                    // DLLs that DuckDB downloads to %USERPROFILE%\.duckdb at
-                    // runtime. LOAD takes the explicit file path — setting
-                    // extension_directory does not work here because DuckDB then
-                    // expects a v<version>/<platform> subfolder structure.
-                    string spatialBundled = Path.Combine(extensionsPath, "spatial.duckdb_extension");
-                    string httpfsBundled = Path.Combine(extensionsPath, "httpfs.duckdb_extension");
-
-                    if (File.Exists(spatialBundled) && File.Exists(httpfsBundled))
-                    {
-                        command.CommandText = $@"
-                            LOAD '{spatialBundled.Replace('\\', '/')}';
-                            LOAD '{httpfsBundled.Replace('\\', '/')}';
-                        ";
-                        await command.ExecuteNonQueryAsync(cancellationToken);
-                        System.Diagnostics.Debug.WriteLine($"Loaded bundled DuckDB extensions from {extensionsPath}");
-                    }
-                    else
-                    {
-                        System.Diagnostics.Debug.WriteLine($"No bundled extensions at {extensionsPath}; trying network INSTALL...");
-
-                        command.CommandText = @"
-                            INSTALL spatial;
-                            INSTALL httpfs;
-                            LOAD spatial;
-                            LOAD httpfs;
-                        ";
-
-                        bool installSuccess = false;
-                        int maxRetries = 3;
-                        for (int i = 0; i < maxRetries; i++)
-                        {
-                            try
-                            {
-                                await command.ExecuteNonQueryAsync(cancellationToken);
-                                System.Diagnostics.Debug.WriteLine($"Successfully installed extensions directly on attempt {i + 1}");
-                                installSuccess = true;
-                                break; // Success, exit retry loop
-                            }
-                            catch (Exception ex)
-                            {
-                                System.Diagnostics.Debug.WriteLine($"Direct installation attempt {i + 1} failed: {ex.Message}");
-                                if (i < maxRetries - 1)
-                                {
-                                    await Task.Delay(2000, cancellationToken); // Wait 2 seconds before retrying
-                                }
-                            }
-                        }
-
-                        if (!installSuccess)
-                        {
-                            throw new Exception(
-                                $"Runtime installation of DuckDB extensions failed and no bundled extensions were found at {extensionsPath}. " +
-                                "If the error mentions an Application Control policy, your organization blocks DLLs downloaded to the user profile — " +
-                                "bundle the extensions with the add-in instead (see Extensions/README.txt).");
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // If both methods failed, show a more informative error with detailed instructions
-                    throw new Exception(
-                        $"Failed to load DuckDB extensions: {ex.Message}\n\n" +
-                        "To resolve this issue:\n" +
-                        "1. Place spatial.duckdb_extension and httpfs.duckdb_extension in the add-in's Extensions folder\n" +
-                        "2. The extensions must match the DuckDB version used by the add-in (see Extensions/README.txt)\n" +
-                        $"3. Current extension search path: {extensionsPath}", ex);
-                }
-
-                // Extensions loaded successfully — mark as initialized so a retry
-                // after a settings failure doesn't re-open the connection.
-                _isInitialized = true;
-
-                // Configure DuckDB settings for optimal performance.
-                // Batched into a single multi-statement execution to reduce round trips.
-                try
-                {
-                    int threads = Math.Max(1, Environment.ProcessorCount);
-                    string tempDir = Path.GetTempPath().Replace('\\', '/');
-                    command.CommandText = $@"
-                        SET s3_region='us-west-2';
-                        SET enable_http_metadata_cache=true;
-                        SET enable_object_cache=true;
-                        SET enable_progress_bar=true;
-                        SET memory_limit='2GB';
-                        SET max_memory='4GB';
-                        SET temp_directory='{tempDir}';
-                        SET threads={threads};
-                    ";
-                    await command.ExecuteNonQueryAsync(cancellationToken);
-                    System.Diagnostics.Debug.WriteLine($"DuckDB settings configured successfully (threads={threads})");
-                }
-                catch (Exception settingsEx)
-                {
-                    System.Diagnostics.Debug.WriteLine($"Warning: Could not set some DuckDB settings: {settingsEx.Message}");
-                    // Continue — these are optimizations, not required for functionality
-                }
-
-            }
-            catch (Exception ex)
-            {
-                throw new Exception($"Failed to initialize DuckDB: {ex.Message}", ex);
-            }
-        }
+        public Task InitializeDuckDBAsync(CancellationToken cancellationToken = default)
+            => _duckDb.InitializeAsync(cancellationToken);
 
         /// <summary>
         /// Exports a small GeoJSON sample of an Overture S3 dataset for the
@@ -2142,8 +2026,8 @@ namespace DuckDBGeoparquet.Services
         public void Dispose()
         {
             if (_isDisposed) return;
-            
-            _connection?.Dispose();
+
+            _duckDb?.Dispose();
             _pendingLayers?.Clear();
             _isDisposed = true;
             GC.SuppressFinalize(this);

--- a/Services/DuckDBManager.cs
+++ b/Services/DuckDBManager.cs
@@ -1,0 +1,155 @@
+using DuckDB.NET.Data;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Owns the DuckDB connection lifecycle for the add-in: opening the
+    /// in-memory database, loading the spatial/httpfs extensions (bundled
+    /// first, network INSTALL as fallback), and applying session settings.
+    /// Extracted from DataProcessor (Phase 2c stage 2).
+    /// </summary>
+    public sealed class DuckDBManager : IDisposable
+    {
+        private readonly DuckDBConnection _connection = new("DataSource=:memory:");
+        private bool _isDisposed;
+
+        /// <summary>The open connection. Valid after <see cref="InitializeAsync"/> succeeds.</summary>
+        public DuckDBConnection Connection => _connection;
+
+        /// <summary>True once extensions are loaded and the connection is usable.</summary>
+        public bool IsInitialized { get; private set; }
+
+        public async Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            if (IsInitialized) return;
+
+            try
+            {
+                await _connection.OpenAsync();
+
+                // Get the various potential paths where extensions might be found
+                string addInFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                string extensionsPath = Path.Combine(addInFolder, "Extensions");
+
+                using var command = _connection.CreateCommand();
+
+                try
+                {
+                    // Prefer bundled extensions when present. They load from the
+                    // add-in's own (trusted) install folder, so they work offline
+                    // and on machines where Application Control policies block
+                    // DLLs that DuckDB downloads to %USERPROFILE%\.duckdb at
+                    // runtime. LOAD takes the explicit file path — setting
+                    // extension_directory does not work here because DuckDB then
+                    // expects a v<version>/<platform> subfolder structure.
+                    string spatialBundled = Path.Combine(extensionsPath, "spatial.duckdb_extension");
+                    string httpfsBundled = Path.Combine(extensionsPath, "httpfs.duckdb_extension");
+
+                    if (File.Exists(spatialBundled) && File.Exists(httpfsBundled))
+                    {
+                        command.CommandText = $@"
+                            LOAD '{spatialBundled.Replace('\\', '/')}';
+                            LOAD '{httpfsBundled.Replace('\\', '/')}';
+                        ";
+                        await command.ExecuteNonQueryAsync(cancellationToken);
+                        System.Diagnostics.Debug.WriteLine($"Loaded bundled DuckDB extensions from {extensionsPath}");
+                    }
+                    else
+                    {
+                        System.Diagnostics.Debug.WriteLine($"No bundled extensions at {extensionsPath}; trying network INSTALL...");
+
+                        command.CommandText = @"
+                            INSTALL spatial;
+                            INSTALL httpfs;
+                            LOAD spatial;
+                            LOAD httpfs;
+                        ";
+
+                        bool installSuccess = false;
+                        int maxRetries = 3;
+                        for (int i = 0; i < maxRetries; i++)
+                        {
+                            try
+                            {
+                                await command.ExecuteNonQueryAsync(cancellationToken);
+                                System.Diagnostics.Debug.WriteLine($"Successfully installed extensions directly on attempt {i + 1}");
+                                installSuccess = true;
+                                break; // Success, exit retry loop
+                            }
+                            catch (Exception ex)
+                            {
+                                System.Diagnostics.Debug.WriteLine($"Direct installation attempt {i + 1} failed: {ex.Message}");
+                                if (i < maxRetries - 1)
+                                {
+                                    await Task.Delay(2000, cancellationToken); // Wait 2 seconds before retrying
+                                }
+                            }
+                        }
+
+                        if (!installSuccess)
+                        {
+                            throw new Exception(
+                                $"Runtime installation of DuckDB extensions failed and no bundled extensions were found at {extensionsPath}. " +
+                                "If the error mentions an Application Control policy, your organization blocks DLLs downloaded to the user profile — " +
+                                "bundle the extensions with the add-in instead (see Extensions/README.txt).");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // If both methods failed, show a more informative error with detailed instructions
+                    throw new Exception(
+                        $"Failed to load DuckDB extensions: {ex.Message}\n\n" +
+                        "To resolve this issue:\n" +
+                        "1. Place spatial.duckdb_extension and httpfs.duckdb_extension in the add-in's Extensions folder\n" +
+                        "2. The extensions must match the DuckDB version used by the add-in (see Extensions/README.txt)\n" +
+                        $"3. Current extension search path: {extensionsPath}", ex);
+                }
+
+                // Extensions loaded successfully — mark as initialized so a retry
+                // after a settings failure doesn't re-open the connection.
+                IsInitialized = true;
+
+                // Configure DuckDB settings for optimal performance.
+                // Batched into a single multi-statement execution to reduce round trips.
+                try
+                {
+                    int threads = Math.Max(1, Environment.ProcessorCount);
+                    string tempDir = Path.GetTempPath().Replace('\\', '/');
+                    command.CommandText = $@"
+                        SET s3_region='us-west-2';
+                        SET enable_http_metadata_cache=true;
+                        SET enable_object_cache=true;
+                        SET enable_progress_bar=true;
+                        SET memory_limit='2GB';
+                        SET max_memory='4GB';
+                        SET temp_directory='{tempDir}';
+                        SET threads={threads};
+                    ";
+                    await command.ExecuteNonQueryAsync(cancellationToken);
+                    System.Diagnostics.Debug.WriteLine($"DuckDB settings configured successfully (threads={threads})");
+                }
+                catch (Exception settingsEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Warning: Could not set some DuckDB settings: {settingsEx.Message}");
+                    // Continue — these are optimizations, not required for functionality
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to initialize DuckDB: {ex.Message}", ex);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _connection?.Dispose();
+            _isDisposed = true;
+        }
+    }
+}

--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -82,12 +82,13 @@ drives the extent.
 - `Services/PreviewBridge.cs` message handling is covered by tests
   (camelCase contract, wkid default, malformed-message tolerance).
 
-**Remaining stages** (each is its own PR-sized chunk):
-- Stage 2: split `DataProcessor.cs` — `DuckDBManager` (connection +
-  extension loading), `S3Ingester`, `ParquetExporter`, `LayerManager`,
-  `GeocoderEngine`, with `DataProcessor` as a thin façade. Extract the pure
-  parts (column projection, query text builders) into testable classes as
-  they move.
+**Stage 2 (in progress):** split `DataProcessor.cs` behind a thin façade.
+- `DuckDBManager` (connection lifecycle + extension loading) — DONE.
+  `DataProcessor` proxies `_connection`/`_isInitialized` so call sites are
+  unchanged; behavior and error messages are moved verbatim.
+- Remaining: `S3Ingester`, `ParquetExporter`, `LayerManager`,
+  `GeocoderEngine`. Extract the pure parts (column projection, query text
+  builders) into testable classes as they move.
 - Stage 3: extract `DataLoadOrchestrator` and `MfcOrchestrator` from
   `WizardDockpaneViewModel.cs` (load pipeline, bulk replacement, P/Invoke
   deletion, extent resolution; MFC creation).


### PR DESCRIPTION
## Summary

First slice of the `DataProcessor` split from `docs/PHASE2_PLAN.md` Phase 2c stage 2, following #11.

- New **`Services/DuckDBManager.cs`**: owns the DuckDB connection lifecycle — opening the in-memory database, the bundled-first extension loading (with the network `INSTALL` fallback and the Application Control guidance messages), and session settings. The code moves **verbatim**, including all error-message text, so runtime behavior is identical.
- `DataProcessor` shrinks accordingly: `InitializeDuckDBAsync` delegates, `Dispose` disposes the manager, and `_connection`/`_isInitialized` become read-only proxy properties so the ~11 existing call sites compile unchanged. No call-site churn keeps this diff reviewable.

Remaining stage-2 extractions (follow-up PRs): `S3Ingester`, `ParquetExporter`, `LayerManager`, `GeocoderEngine`.

## Testing

- CI build + the 14 existing unit tests
- Behavior-neutral by construction (verbatim code move + proxies); the initialization path was field-verified on a County-managed machine in #10 and the log lines it emits are unchanged, so a quick smoke run in Pro (open wizard → "Loaded bundled DuckDB extensions from …" → small load) confirms parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1fTVZhA1frgU7EpZeuQnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1fTVZhA1frgU7EpZeuQnJ)_