### PR TITLE
Geocoder: DataProcessor extraction, working hybrid locator, and Locate-pane workflow

### DIFF
--- a/Config.daml
+++ b/Config.daml
@@ -32,10 +32,10 @@
                         Download Overture Maps data as GeoParquet files
 						<disabledText>Unable to launch Overture Maps Data Loader at this time</disabledText></tooltip>
 				</button>
-				<button id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane_ShowButton" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="G" condition="esri_mapping_mapPane" extendedCaption="Search Overture ROI Address and Place Data">
-					<tooltip heading="Overture ROI Geocoder">
-                        Search loaded Overture address and place data in your region of interest
-						<disabledText>Unable to open Overture ROI Geocoder at this time</disabledText></tooltip>
+				<button id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane_ShowButton" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="G" condition="esri_mapping_mapPane" extendedCaption="Search Loaded Overture Address and Place Data">
+					<tooltip heading="Overture Geocoder">
+                        Search loaded Overture address and place data
+						<disabledText>Unable to open Overture Geocoder at this time</disabledText></tooltip>
 				</button>
 				<!-- Custom Extent Tool -->
 				<tool id="DuckDBGeoparquet_CustomExtentTool" className="DuckDBGeoparquet.Views.CustomExtentTool" caption="Draw Custom Extent" loadOnClick="true" smallImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/SelectTool16.png" largeImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/SelectTool32.png" condition="esri_mapping_mapPane" keytip="E">
@@ -48,7 +48,7 @@
 				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
 					<content className="DuckDBGeoparquet.Views.WizardDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture ROI Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
 					<content className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneView" />
 				</dockPane>
 			</dockPanes>

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -9,6 +9,7 @@
 		     SDK assemblies, which only resolve usefully on a machine with Pro
 		     installed. Anything linked here must stay free of ArcGIS types. -->
 		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
+		<Compile Include="..\Services\GeocodeResultLabels.cs" Link="Linked\GeocodeResultLabels.cs" />
 		<Compile Include="..\Services\GeocodeFileQueryBuilder.cs" Link="Linked\GeocodeFileQueryBuilder.cs" />
 		<Compile Include="..\Services\GeocodeTextNormalizer.cs" Link="Linked\GeocodeTextNormalizer.cs" />
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -8,6 +8,7 @@
 		     add-in project: a project reference would pull in the ArcGIS Pro
 		     SDK assemblies, which only resolve usefully on a machine with Pro
 		     installed. Anything linked here must stay free of ArcGIS types. -->
+		<Compile Include="..\Models\GeocodeCandidate.cs" Link="Linked\GeocodeCandidate.cs" />
 		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
 		<Compile Include="..\Services\GeocodeResultLabels.cs" Link="Linked\GeocodeResultLabels.cs" />
 		<Compile Include="..\Services\GeocodeFileQueryBuilder.cs" Link="Linked\GeocodeFileQueryBuilder.cs" />

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -9,6 +9,7 @@
 		     SDK assemblies, which only resolve usefully on a machine with Pro
 		     installed. Anything linked here must stay free of ArcGIS types. -->
 		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
+		<Compile Include="..\Services\GeocodeTextNormalizer.cs" Link="Linked\GeocodeTextNormalizer.cs" />
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
 		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />
 	</ItemGroup>

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -9,6 +9,7 @@
 		     SDK assemblies, which only resolve usefully on a machine with Pro
 		     installed. Anything linked here must stay free of ArcGIS types. -->
 		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
+		<Compile Include="..\Services\GeocodeFileQueryBuilder.cs" Link="Linked\GeocodeFileQueryBuilder.cs" />
 		<Compile Include="..\Services\GeocodeTextNormalizer.cs" Link="Linked\GeocodeTextNormalizer.cs" />
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
 		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />

--- a/DuckDBGeoparquet.Tests/GeoParquetSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GeoParquetSqlTests.cs
@@ -73,6 +73,16 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("bbox.ymax >= 2", predicate);
         }
 
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("plain", "plain")]
+        [InlineData("O'Brien's", "O''Brien''s")]
+        public void EscapeSqlLiteral_DoublesSingleQuotes(string input, string expected)
+        {
+            Assert.Equal(expected, GeoParquetSql.EscapeSqlLiteral(input));
+        }
+
         [Fact]
         public void BuildExtentPolygon_ClosesTheRing()
         {

--- a/DuckDBGeoparquet.Tests/GeocodeFileQueryBuilderTests.cs
+++ b/DuckDBGeoparquet.Tests/GeocodeFileQueryBuilderTests.cs
@@ -1,0 +1,30 @@
+using DuckDBGeoparquet.Services;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class GeocodeFileQueryBuilderTests
+    {
+        [Fact]
+        public void BuildQueryVariants_IncludesProgressiveFallbacks()
+        {
+            var variants = GeocodeFileQueryBuilder.BuildQueryVariants(
+                "1939 E OLIVE AVE", "FRESNO", "CA", "93701");
+
+            Assert.Equal("1939 E OLIVE AVE, FRESNO, CA 93701", variants[0]);
+            Assert.Contains("1939 E OLIVE AVE, 93701", variants);
+            Assert.Contains("1939 E OLIVE AVE", variants);
+        }
+
+        [Fact]
+        public void BuildQueryVariants_DeduplicatesEquivalentVariants()
+        {
+            var variants = GeocodeFileQueryBuilder.BuildQueryVariants(
+                "1939 E OLIVE AVE", "", "", "93701");
+
+            Assert.Equal(2, variants.Count);
+            Assert.Equal("1939 E OLIVE AVE, 93701", variants[0]);
+            Assert.Equal("1939 E OLIVE AVE", variants[1]);
+        }
+    }
+}

--- a/DuckDBGeoparquet.Tests/GeocodeResultLabelsTests.cs
+++ b/DuckDBGeoparquet.Tests/GeocodeResultLabelsTests.cs
@@ -1,3 +1,4 @@
+using DuckDBGeoparquet.Models;
 using DuckDBGeoparquet.Services;
 using Xunit;
 
@@ -23,6 +24,24 @@ namespace DuckDBGeoparquet.Tests
         public void GetConfidenceSummary_MapsInternalTiersToFriendlyLabels(string confidenceTier, string expected)
         {
             Assert.Equal(expected, GeocodeResultLabels.GetConfidenceSummary(confidenceTier));
+        }
+
+        [Fact]
+        public void GeocodeCandidate_ExposesFriendlyMatchAndConfidenceLabels()
+        {
+            var candidate = new GeocodeCandidate
+            {
+                SourceType = "Address",
+                MatchTier = "prefix",
+                ConfidenceTier = "Medium"
+            };
+
+            Assert.Equal("Strong address match", candidate.MatchTier);
+            Assert.Equal("Strong address match", candidate.MatchSummary);
+            Assert.Equal("Good candidate", candidate.ConfidenceTier);
+            Assert.Equal("Good candidate", candidate.ConfidenceSummary);
+            Assert.Equal("prefix", candidate.RawMatchTier);
+            Assert.Equal("Medium", candidate.RawConfidenceTier);
         }
     }
 }

--- a/DuckDBGeoparquet.Tests/GeocodeResultLabelsTests.cs
+++ b/DuckDBGeoparquet.Tests/GeocodeResultLabelsTests.cs
@@ -1,0 +1,28 @@
+using DuckDBGeoparquet.Services;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class GeocodeResultLabelsTests
+    {
+        [Theory]
+        [InlineData("exact", "Address", "Exact address match")]
+        [InlineData("prefix", "Address", "Strong address match")]
+        [InlineData("contains", "Place", "Partial place match")]
+        [InlineData("token", "Address", "Approximate text match")]
+        [InlineData("locator", "Locator", "Matched by ArcGIS locator")]
+        public void GetMatchSummary_MapsInternalTiersToFriendlyLabels(string matchTier, string sourceType, string expected)
+        {
+            Assert.Equal(expected, GeocodeResultLabels.GetMatchSummary(matchTier, sourceType));
+        }
+
+        [Theory]
+        [InlineData("High", "High confidence")]
+        [InlineData("Medium", "Good candidate")]
+        [InlineData("Low", "Needs review")]
+        public void GetConfidenceSummary_MapsInternalTiersToFriendlyLabels(string confidenceTier, string expected)
+        {
+            Assert.Equal(expected, GeocodeResultLabels.GetConfidenceSummary(confidenceTier));
+        }
+    }
+}

--- a/DuckDBGeoparquet.Tests/GeocodeTextNormalizerTests.cs
+++ b/DuckDBGeoparquet.Tests/GeocodeTextNormalizerTests.cs
@@ -1,0 +1,20 @@
+using DuckDBGeoparquet.Services;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class GeocodeTextNormalizerTests
+    {
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("   ", "")]
+        [InlineData("1939 OLIVE", "1939 olive")]
+        [InlineData("147 E ESCALON AVE, FRESNO, CA 93710-5109", "147 e escalon ave fresno ca 93710 5109")]
+        [InlineData("  2438   Tulare St. Apt #200  ", "2438 tulare st apt 200")]
+        public void NormalizeForSearch_StripsPunctuationAndCollapsesWhitespace(string input, string expected)
+        {
+            Assert.Equal(expected, GeocodeTextNormalizer.NormalizeForSearch(input));
+        }
+    }
+}

--- a/Models/GeocodeCandidate.cs
+++ b/Models/GeocodeCandidate.cs
@@ -4,14 +4,29 @@ namespace DuckDBGeoparquet.Models
 {
     public class GeocodeCandidate
     {
+        private string _rawMatchTier;
+        private string _rawConfidenceTier;
+
         public string DisplayLabel { get; set; }
         public double Longitude { get; set; }
         public double Latitude { get; set; }
         public string SourceType { get; set; }
-        public string MatchTier { get; set; }
-        public string ConfidenceTier { get; set; }
+        public string MatchTier
+        {
+            get => GeocodeResultLabels.GetMatchSummary(_rawMatchTier, SourceType);
+            set => _rawMatchTier = value;
+        }
+
+        public string ConfidenceTier
+        {
+            get => GeocodeResultLabels.GetConfidenceSummary(_rawConfidenceTier);
+            set => _rawConfidenceTier = value;
+        }
+
+        public string RawMatchTier => _rawMatchTier;
+        public string RawConfidenceTier => _rawConfidenceTier;
         public int Score { get; set; }
-        public string MatchSummary => GeocodeResultLabels.GetMatchSummary(MatchTier, SourceType);
-        public string ConfidenceSummary => GeocodeResultLabels.GetConfidenceSummary(ConfidenceTier);
+        public string MatchSummary => MatchTier;
+        public string ConfidenceSummary => ConfidenceTier;
     }
 }

--- a/Models/GeocodeCandidate.cs
+++ b/Models/GeocodeCandidate.cs
@@ -1,3 +1,5 @@
+using DuckDBGeoparquet.Services;
+
 namespace DuckDBGeoparquet.Models
 {
     public class GeocodeCandidate
@@ -9,5 +11,7 @@ namespace DuckDBGeoparquet.Models
         public string MatchTier { get; set; }
         public string ConfidenceTier { get; set; }
         public int Score { get; set; }
+        public string MatchSummary => GeocodeResultLabels.GetMatchSummary(MatchTier, SourceType);
+        public string ConfidenceSummary => GeocodeResultLabels.GetConfidenceSummary(ConfidenceTier);
     }
 }

--- a/Services/DataProcessor.cs
+++ b/Services/DataProcessor.cs
@@ -32,6 +32,7 @@ namespace DuckDBGeoparquet.Services
     public class DataProcessor : IDisposable
     {
         private readonly DuckDBManager _duckDb;
+        private readonly GeocoderEngine _geocoder;
 
         // Proxies keep the many existing call sites unchanged while the
         // connection lifecycle lives in DuckDBManager (Phase 2c stage 2).
@@ -129,6 +130,7 @@ namespace DuckDBGeoparquet.Services
         public DataProcessor()
         {
             _duckDb = new DuckDBManager();
+            _geocoder = new GeocoderEngine(_duckDb);
             _pendingLayers = new List<LayerCreationInfo>();
         }
 
@@ -1827,201 +1829,13 @@ namespace DuckDBGeoparquet.Services
             return results;
         }
 
-        public async Task<List<GeocodeCandidate>> SearchAddressCandidatesAsync(string parquetGlobPath, string normalizedQuery, ExtentBounds extent = null, int maxResults = 25, CancellationToken cancellationToken = default)
-        {
-            return await SearchLocalCandidatesAsync(parquetGlobPath, normalizedQuery, "Address", extent, maxResults, 40, cancellationToken);
-        }
+        // Geocoding moved to GeocoderEngine (Phase 2c stage 2); these
+        // wrappers preserve the public API for existing callers.
+        public Task<List<GeocodeCandidate>> SearchAddressCandidatesAsync(string parquetGlobPath, string normalizedQuery, ExtentBounds extent = null, int maxResults = 25, CancellationToken cancellationToken = default)
+            => _geocoder.SearchAddressCandidatesAsync(parquetGlobPath, normalizedQuery, extent, maxResults, cancellationToken);
 
-        public async Task<List<GeocodeCandidate>> SearchPlaceCandidatesAsync(string parquetGlobPath, string normalizedQuery, ExtentBounds extent = null, int maxResults = 25, CancellationToken cancellationToken = default)
-        {
-            return await SearchLocalCandidatesAsync(parquetGlobPath, normalizedQuery, "Place", extent, maxResults, 0, cancellationToken);
-        }
-
-        public async Task<List<GeocodeCandidate>> SearchLocalCandidatesAsync(
-            string parquetGlobPath,
-            string normalizedQuery,
-            string sourceType,
-            ExtentBounds extent = null,
-            int maxResults = 25,
-            int sourceBias = 0,
-            CancellationToken cancellationToken = default)
-        {
-            var candidates = new List<GeocodeCandidate>();
-            if (string.IsNullOrWhiteSpace(parquetGlobPath) || string.IsNullOrWhiteSpace(normalizedQuery))
-            {
-                return candidates;
-            }
-
-            int safeLimit = Math.Clamp(maxResults, 1, 100);
-            string escapedPath = EscapeSqlLiteral(parquetGlobPath.Replace('\\', '/'));
-            string escapedQuery = EscapeSqlLiteral(normalizedQuery);
-            string escapedSourceType = EscapeSqlLiteral(sourceType ?? "Unknown");
-
-            using var command = _connection.CreateCommand();
-
-            // Read schema once so SQL only references columns that exist.
-            command.CommandText = $@"
-                CREATE OR REPLACE TABLE geocoder_schema_probe AS
-                SELECT * FROM read_parquet('{escapedPath}', hive_partitioning=1) LIMIT 0;
-            ";
-            await command.ExecuteNonQueryAsync(cancellationToken);
-
-            command.CommandText = "DESCRIBE geocoder_schema_probe";
-            var availableColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            using (var schemaReader = await command.ExecuteReaderAsync(cancellationToken))
-            {
-                while (await schemaReader.ReadAsync(cancellationToken))
-                {
-                    if (!schemaReader.IsDBNull(0))
-                    {
-                        availableColumns.Add(schemaReader.GetString(0));
-                    }
-                }
-            }
-
-            if (!availableColumns.Contains("geometry"))
-            {
-                return candidates;
-            }
-
-            static string FirstExistingExpression(HashSet<string> columns, params string[] names)
-            {
-                foreach (var name in names)
-                {
-                    if (columns.Contains(name))
-                    {
-                        return $"CAST({name} AS VARCHAR)";
-                    }
-                }
-
-                return "''";
-            }
-
-            string numberExpr = FirstExistingExpression(availableColumns, "number", "housenumber", "house_number");
-            string streetExpr = FirstExistingExpression(availableColumns, "street", "street_name", "road", "name");
-            string localityExpr = FirstExistingExpression(availableColumns, "city", "locality", "district", "admin2", "subregion");
-            string regionExpr = FirstExistingExpression(availableColumns, "region", "state", "province", "admin1");
-            string postalExpr = FirstExistingExpression(availableColumns, "postcode", "postal_code", "zip");
-            string countryExpr = FirstExistingExpression(availableColumns, "country", "country_code");
-            string placeNameExpr = FirstExistingExpression(availableColumns, "name", "name_primary", "names", "brand");
-            string categoryExpr = FirstExistingExpression(availableColumns, "category", "class", "subtype", "kind");
-
-            string tokenCondition = string.Join(" AND ", normalizedQuery
-                .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(token => $"search_text LIKE '%{EscapeSqlLiteral(token)}%'"));
-            if (string.IsNullOrWhiteSpace(tokenCondition))
-            {
-                tokenCondition = "FALSE";
-            }
-
-            string extentFilter = string.Empty;
-            if (extent != null)
-            {
-                string xMinStr = extent.XMin.ToString("G", CultureInfo.InvariantCulture);
-                string yMinStr = extent.YMin.ToString("G", CultureInfo.InvariantCulture);
-                string xMaxStr = extent.XMax.ToString("G", CultureInfo.InvariantCulture);
-                string yMaxStr = extent.YMax.ToString("G", CultureInfo.InvariantCulture);
-
-                if (availableColumns.Contains("bbox"))
-                {
-                    extentFilter = $@"
-                        AND bbox.xmin <= {xMaxStr}
-                        AND bbox.xmax >= {xMinStr}
-                        AND bbox.ymin <= {yMaxStr}
-                        AND bbox.ymax >= {yMinStr}";
-                }
-                else
-                {
-                    string extentPolygon = $"ST_GeomFromText('POLYGON(({xMinStr} {yMinStr}, {xMaxStr} {yMinStr}, {xMaxStr} {yMaxStr}, {xMinStr} {yMaxStr}, {xMinStr} {yMinStr}))')";
-                    extentFilter = $@" AND ST_Intersects(geometry, {extentPolygon})";
-                }
-            }
-
-            string searchSql = $@"
-                WITH prepared AS (
-                    SELECT
-                        trim(concat_ws(', ',
-                            nullif(trim(concat_ws(' ', nullif({numberExpr}, ''), nullif({streetExpr}, ''), nullif({placeNameExpr}, ''))), ''),
-                            nullif({localityExpr}, ''),
-                            nullif({regionExpr}, ''),
-                            nullif({postalExpr}, ''),
-                            nullif({countryExpr}, '')
-                        )) AS display_label,
-                        CAST(ST_X(geometry) AS DOUBLE) AS longitude,
-                        CAST(ST_Y(geometry) AS DOUBLE) AS latitude,
-                        lower(trim(concat_ws(' ',
-                            nullif({numberExpr}, ''),
-                            nullif({streetExpr}, ''),
-                            nullif({placeNameExpr}, ''),
-                            nullif({categoryExpr}, ''),
-                            nullif({localityExpr}, ''),
-                            nullif({regionExpr}, ''),
-                            nullif({postalExpr}, ''),
-                            nullif({countryExpr}, '')
-                        ))) AS search_text
-                    FROM read_parquet('{escapedPath}', hive_partitioning=1)
-                    WHERE geometry IS NOT NULL
-                    {extentFilter}
-                ),
-                ranked AS (
-                    SELECT
-                        display_label,
-                        longitude,
-                        latitude,
-                        CASE
-                            WHEN search_text = '{escapedQuery}' THEN 300 + {sourceBias}
-                            WHEN search_text LIKE '{escapedQuery}%' THEN 220 + {sourceBias}
-                            WHEN search_text LIKE '%{escapedQuery}%' THEN 170 + {sourceBias}
-                            WHEN {tokenCondition} THEN 120 + {sourceBias}
-                            ELSE 0
-                        END AS score
-                    FROM prepared
-                    WHERE search_text LIKE '%{escapedQuery}%'
-                       OR ({tokenCondition})
-                )
-                SELECT
-                    display_label,
-                    longitude,
-                    latitude,
-                    '{escapedSourceType}' AS source_type,
-                    CASE
-                        WHEN score >= 300 THEN 'exact'
-                        WHEN score >= 200 THEN 'prefix'
-                        WHEN score >= 150 THEN 'contains'
-                        ELSE 'token'
-                    END AS match_tier,
-                    score
-                FROM ranked
-                WHERE score > 0
-                  AND display_label IS NOT NULL
-                  AND display_label <> ''
-                ORDER BY score DESC, display_label
-                LIMIT {safeLimit};";
-
-            command.CommandText = searchSql;
-            using var resultReader = await command.ExecuteReaderAsync(cancellationToken);
-            while (await resultReader.ReadAsync(cancellationToken))
-            {
-                int score = resultReader.IsDBNull(5) ? 0 : Convert.ToInt32(resultReader.GetValue(5), CultureInfo.InvariantCulture);
-                candidates.Add(new GeocodeCandidate
-                {
-                    DisplayLabel = resultReader.IsDBNull(0) ? string.Empty : resultReader.GetString(0),
-                    Longitude = resultReader.IsDBNull(1) ? 0 : Convert.ToDouble(resultReader.GetValue(1), CultureInfo.InvariantCulture),
-                    Latitude = resultReader.IsDBNull(2) ? 0 : Convert.ToDouble(resultReader.GetValue(2), CultureInfo.InvariantCulture),
-                    SourceType = resultReader.IsDBNull(3) ? "Unknown" : resultReader.GetString(3),
-                    MatchTier = resultReader.IsDBNull(4) ? "token" : resultReader.GetString(4),
-                    Score = score,
-                    ConfidenceTier = score >= 280 ? "High" : score >= 190 ? "Medium" : "Low"
-                });
-            }
-
-            return candidates;
-        }
-
-        private static string EscapeSqlLiteral(string value)
-        {
-            return string.IsNullOrEmpty(value) ? string.Empty : value.Replace("'", "''");
-        }
+        public Task<List<GeocodeCandidate>> SearchPlaceCandidatesAsync(string parquetGlobPath, string normalizedQuery, ExtentBounds extent = null, int maxResults = 25, CancellationToken cancellationToken = default)
+            => _geocoder.SearchPlaceCandidatesAsync(parquetGlobPath, normalizedQuery, extent, maxResults, cancellationToken);
 
         public void Dispose()
         {

--- a/Services/GeoParquetSql.cs
+++ b/Services/GeoParquetSql.cs
@@ -52,6 +52,10 @@ namespace DuckDBGeoparquet.Services
         public static string FormatCoordinate(double value) =>
             value.ToString("G", CultureInfo.InvariantCulture);
 
+        /// <summary>Escapes a value for embedding in a single-quoted SQL literal.</summary>
+        public static string EscapeSqlLiteral(string value) =>
+            string.IsNullOrEmpty(value) ? string.Empty : value.Replace("'", "''");
+
         /// <summary>
         /// Builds the ST_GeomFromText expression for an extent's polygon,
         /// used for ST_Intersects checks and geometry clipping.

--- a/Services/GeocodeFileQueryBuilder.cs
+++ b/Services/GeocodeFileQueryBuilder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Builds progressively broader search queries for file-geocoding rows.
+    /// This mirrors how a geocoder treats locality fields as helpful context
+    /// rather than mandatory text that every dataset row must contain.
+    /// </summary>
+    public static class GeocodeFileQueryBuilder
+    {
+        public static IReadOnlyList<string> BuildQueryVariants(string address, string city, string state, string zip)
+        {
+            var variants = new List<string>();
+            string cleanAddress = CleanPart(address);
+            string cleanCity = CleanPart(city);
+            string cleanState = CleanPart(state);
+            string cleanZip = CleanPart(zip);
+
+            if (string.IsNullOrWhiteSpace(cleanAddress))
+            {
+                return [];
+            }
+
+            string cityState = Join(", ", cleanCity, cleanState);
+            string fullLocality = cityState;
+            if (!string.IsNullOrWhiteSpace(cleanZip))
+            {
+                fullLocality = string.IsNullOrWhiteSpace(fullLocality)
+                    ? cleanZip
+                    : $"{fullLocality} {cleanZip}";
+            }
+
+            AddVariant(variants, cleanAddress, fullLocality);
+            AddVariant(variants, cleanAddress, cleanZip);
+            AddVariant(variants, cleanAddress, cleanCity);
+            AddVariant(variants, cleanAddress, cityState);
+            AddVariant(variants, cleanAddress, null);
+
+            return variants;
+        }
+
+        private static void AddVariant(List<string> variants, string address, string locality)
+        {
+            string candidate = string.IsNullOrWhiteSpace(locality)
+                ? address
+                : $"{address}, {locality}";
+
+            if (!variants.Contains(candidate, StringComparer.OrdinalIgnoreCase))
+            {
+                variants.Add(candidate);
+            }
+        }
+
+        private static string Join(string separator, params string[] values)
+        {
+            return string.Join(separator, values.Where(value => !string.IsNullOrWhiteSpace(value)));
+        }
+
+        private static string CleanPart(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            return string.Join(" ",
+                value.Trim().Trim('"')
+                    .Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
+        }
+    }
+}

--- a/Services/GeocodeResultLabels.cs
+++ b/Services/GeocodeResultLabels.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace DuckDBGeoparquet.Services
+{
+    public static class GeocodeResultLabels
+    {
+        public static string GetMatchSummary(string matchTier, string sourceType)
+        {
+            bool isAddress = string.Equals(sourceType, "Address", StringComparison.OrdinalIgnoreCase);
+            bool isPlace = string.Equals(sourceType, "Place", StringComparison.OrdinalIgnoreCase);
+
+            return (matchTier ?? string.Empty).Trim().ToLowerInvariant() switch
+            {
+                "exact" => isPlace ? "Exact place match" : "Exact address match",
+                "prefix" => isPlace ? "Strong place match" : "Strong address match",
+                "contains" => isPlace ? "Partial place match" : "Partial address match",
+                "token" => "Approximate text match",
+                "locator" => "Matched by ArcGIS locator",
+                _ => "Matched result"
+            };
+        }
+
+        public static string GetConfidenceSummary(string confidenceTier)
+        {
+            return (confidenceTier ?? string.Empty).Trim().ToLowerInvariant() switch
+            {
+                "high" => "High confidence",
+                "medium" => "Good candidate",
+                "low" => "Needs review",
+                _ => "Candidate"
+            };
+        }
+    }
+}

--- a/Services/GeocodeResultWriter.cs
+++ b/Services/GeocodeResultWriter.cs
@@ -51,8 +51,8 @@ namespace DuckDBGeoparquet.Services
                     c.Longitude.ToString("G", CultureInfo.InvariantCulture),
                     c.Latitude.ToString("G", CultureInfo.InvariantCulture),
                     Csv(c.SourceType),
-                    Csv(c.MatchTier),
-                    Csv(c.ConfidenceTier),
+                    Csv(c.MatchSummary),
+                    Csv(c.ConfidenceSummary),
                     c.Score.ToString(CultureInfo.InvariantCulture)));
             }
             File.WriteAllText(csvPath, sb.ToString(), Encoding.UTF8);

--- a/Services/GeocodeResultWriter.cs
+++ b/Services/GeocodeResultWriter.cs
@@ -1,3 +1,4 @@
+using ArcGIS.Core.Data;
 using ArcGIS.Core.Geometry;
 using ArcGIS.Desktop.Core;
 using ArcGIS.Desktop.Core.Geoprocessing;
@@ -69,6 +70,13 @@ namespace DuckDBGeoparquet.Services
                         string.Join(" | ", result.Messages.Select(m => m.Text)));
                 }
 
+                int outputCount = await CountFeaturesAsync(outputPath);
+                if (outputCount != candidates.Count)
+                {
+                    throw new Exception(
+                        $"Output feature class contains {outputCount} row(s), but {candidates.Count} geocode result(s) were expected.");
+                }
+
                 await QueuedTask.Run(() =>
                 {
                     var map = MapView.Active?.Map;
@@ -84,6 +92,27 @@ namespace DuckDBGeoparquet.Services
             {
                 try { File.Delete(csvPath); } catch { /* temp file; best effort */ }
             }
+        }
+
+        private static async Task<int> CountFeaturesAsync(string featureClassPath)
+        {
+            return await QueuedTask.Run(() =>
+            {
+                string gdbPath = Path.GetDirectoryName(featureClassPath);
+                string featureClassName = Path.GetFileName(featureClassPath);
+                var gdbConnectionPath = new FileGeodatabaseConnectionPath(new Uri(gdbPath));
+                using var gdb = new Geodatabase(gdbConnectionPath);
+                using var featureClass = gdb.OpenDataset<FeatureClass>(featureClassName);
+                using var cursor = featureClass.Search(new QueryFilter(), false);
+
+                int count = 0;
+                while (cursor.MoveNext())
+                {
+                    count++;
+                }
+
+                return count;
+            });
         }
 
         private static string Csv(string value)

--- a/Services/GeocodeResultWriter.cs
+++ b/Services/GeocodeResultWriter.cs
@@ -1,0 +1,95 @@
+using ArcGIS.Core.Geometry;
+using ArcGIS.Desktop.Core;
+using ArcGIS.Desktop.Core.Geoprocessing;
+using ArcGIS.Desktop.Framework.Threading.Tasks;
+using ArcGIS.Desktop.Mapping;
+using DuckDBGeoparquet.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Persists geocode results as a point feature class in the project's
+    /// default geodatabase and adds it to the active map — mirroring the
+    /// Locate pane's "Add To Feature Class".
+    /// </summary>
+    public static class GeocodeResultWriter
+    {
+        /// <param name="candidates">Results to persist (WGS84 lon/lat).</param>
+        /// <param name="featureClassName">Output feature class / layer name.</param>
+        /// <param name="sourceQueries">Optional per-candidate input query
+        /// (parallel to <paramref name="candidates"/>), written to a 'query'
+        /// field for file-geocoding output.</param>
+        /// <returns>The output feature class path.</returns>
+        public static async Task<string> WriteToFeatureClassAsync(
+            IReadOnlyList<GeocodeCandidate> candidates,
+            string featureClassName,
+            IReadOnlyList<string> sourceQueries = null)
+        {
+            if (candidates == null || candidates.Count == 0)
+            {
+                throw new ArgumentException("No candidates to write.", nameof(candidates));
+            }
+
+            string csvPath = Path.Combine(Path.GetTempPath(), $"{featureClassName}.csv");
+            var sb = new StringBuilder();
+            sb.AppendLine("query,label,longitude,latitude,source,match,confidence,score");
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                var c = candidates[i];
+                string query = sourceQueries != null && i < sourceQueries.Count ? sourceQueries[i] : string.Empty;
+                sb.AppendLine(string.Join(",",
+                    Csv(query),
+                    Csv(c.DisplayLabel),
+                    c.Longitude.ToString("G", CultureInfo.InvariantCulture),
+                    c.Latitude.ToString("G", CultureInfo.InvariantCulture),
+                    Csv(c.SourceType),
+                    Csv(c.MatchTier),
+                    Csv(c.ConfidenceTier),
+                    c.Score.ToString(CultureInfo.InvariantCulture)));
+            }
+            File.WriteAllText(csvPath, sb.ToString(), Encoding.UTF8);
+
+            try
+            {
+                string outputPath = Path.Combine(Project.Current.DefaultGeodatabasePath, featureClassName);
+                var parameters = Geoprocessing.MakeValueArray(
+                    csvPath, outputPath, "longitude", "latitude", "", SpatialReferences.WGS84);
+                var result = await Geoprocessing.ExecuteToolAsync(
+                    "management.XYTableToPoint", parameters, null, flags: GPExecuteToolFlags.None);
+                if (result.IsFailed)
+                {
+                    throw new Exception("XY Table To Point failed: " +
+                        string.Join(" | ", result.Messages.Select(m => m.Text)));
+                }
+
+                await QueuedTask.Run(() =>
+                {
+                    var map = MapView.Active?.Map;
+                    if (map != null)
+                    {
+                        LayerFactory.Instance.CreateLayer(new Uri(outputPath), map, layerName: featureClassName);
+                    }
+                });
+
+                return outputPath;
+            }
+            finally
+            {
+                try { File.Delete(csvPath); } catch { /* temp file; best effort */ }
+            }
+        }
+
+        private static string Csv(string value)
+        {
+            value ??= string.Empty;
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+    }
+}

--- a/Services/GeocodeTextNormalizer.cs
+++ b/Services/GeocodeTextNormalizer.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Shared text normalization for address/place search input so manual
+    /// searches and file-geocode queries behave consistently.
+    /// </summary>
+    public static class GeocodeTextNormalizer
+    {
+        public static string NormalizeForSearch(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var normalized = new StringBuilder(value.Length);
+            bool previousWasSpace = true;
+
+            foreach (char ch in value.Trim().ToLowerInvariant())
+            {
+                if (char.IsLetterOrDigit(ch))
+                {
+                    normalized.Append(ch);
+                    previousWasSpace = false;
+                }
+                else if (!previousWasSpace)
+                {
+                    normalized.Append(' ');
+                    previousWasSpace = true;
+                }
+            }
+
+            return normalized.ToString().Trim();
+        }
+
+        public static IReadOnlyList<string> Tokenize(string value)
+        {
+            string normalized = NormalizeForSearch(value);
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return [];
+            }
+
+            return normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+    }
+}

--- a/Services/GeocoderEngine.cs
+++ b/Services/GeocoderEngine.cs
@@ -1,0 +1,216 @@
+using DuckDBGeoparquet.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Address/place candidate search over locally downloaded Overture
+    /// GeoParquet, backed by the shared DuckDB connection. Extracted from
+    /// DataProcessor (Phase 2c stage 2); query logic is unchanged.
+    /// </summary>
+    public sealed class GeocoderEngine
+    {
+        private readonly DuckDBManager _duckDb;
+
+        public GeocoderEngine(DuckDBManager duckDb)
+        {
+            _duckDb = duckDb ?? throw new ArgumentNullException(nameof(duckDb));
+        }
+
+        public async Task<List<GeocodeCandidate>> SearchAddressCandidatesAsync(string parquetGlobPath, string normalizedQuery, ExtentBounds extent = null, int maxResults = 25, CancellationToken cancellationToken = default)
+        {
+            return await SearchLocalCandidatesAsync(parquetGlobPath, normalizedQuery, "Address", extent, maxResults, 40, cancellationToken);
+        }
+
+        public async Task<List<GeocodeCandidate>> SearchPlaceCandidatesAsync(string parquetGlobPath, string normalizedQuery, ExtentBounds extent = null, int maxResults = 25, CancellationToken cancellationToken = default)
+        {
+            return await SearchLocalCandidatesAsync(parquetGlobPath, normalizedQuery, "Place", extent, maxResults, 0, cancellationToken);
+        }
+
+        public async Task<List<GeocodeCandidate>> SearchLocalCandidatesAsync(
+            string parquetGlobPath,
+            string normalizedQuery,
+            string sourceType,
+            ExtentBounds extent = null,
+            int maxResults = 25,
+            int sourceBias = 0,
+            CancellationToken cancellationToken = default)
+        {
+            var candidates = new List<GeocodeCandidate>();
+            if (string.IsNullOrWhiteSpace(parquetGlobPath) || string.IsNullOrWhiteSpace(normalizedQuery))
+            {
+                return candidates;
+            }
+
+            int safeLimit = Math.Clamp(maxResults, 1, 100);
+            string escapedPath = GeoParquetSql.EscapeSqlLiteral(parquetGlobPath.Replace('\\', '/'));
+            string escapedQuery = GeoParquetSql.EscapeSqlLiteral(normalizedQuery);
+            string escapedSourceType = GeoParquetSql.EscapeSqlLiteral(sourceType ?? "Unknown");
+
+            using var command = _duckDb.Connection.CreateCommand();
+
+            // Read schema once so SQL only references columns that exist.
+            command.CommandText = $@"
+                CREATE OR REPLACE TABLE geocoder_schema_probe AS
+                SELECT * FROM read_parquet('{escapedPath}', hive_partitioning=1) LIMIT 0;
+            ";
+            await command.ExecuteNonQueryAsync(cancellationToken);
+
+            command.CommandText = "DESCRIBE geocoder_schema_probe";
+            var availableColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            using (var schemaReader = await command.ExecuteReaderAsync(cancellationToken))
+            {
+                while (await schemaReader.ReadAsync(cancellationToken))
+                {
+                    if (!schemaReader.IsDBNull(0))
+                    {
+                        availableColumns.Add(schemaReader.GetString(0));
+                    }
+                }
+            }
+
+            if (!availableColumns.Contains("geometry"))
+            {
+                return candidates;
+            }
+
+            static string FirstExistingExpression(HashSet<string> columns, params string[] names)
+            {
+                foreach (var name in names)
+                {
+                    if (columns.Contains(name))
+                    {
+                        return $"CAST({name} AS VARCHAR)";
+                    }
+                }
+
+                return "''";
+            }
+
+            string numberExpr = FirstExistingExpression(availableColumns, "number", "housenumber", "house_number");
+            string streetExpr = FirstExistingExpression(availableColumns, "street", "street_name", "road", "name");
+            string localityExpr = FirstExistingExpression(availableColumns, "city", "locality", "district", "admin2", "subregion");
+            string regionExpr = FirstExistingExpression(availableColumns, "region", "state", "province", "admin1");
+            string postalExpr = FirstExistingExpression(availableColumns, "postcode", "postal_code", "zip");
+            string countryExpr = FirstExistingExpression(availableColumns, "country", "country_code");
+            string placeNameExpr = FirstExistingExpression(availableColumns, "name", "name_primary", "names", "brand");
+            string categoryExpr = FirstExistingExpression(availableColumns, "category", "class", "subtype", "kind");
+
+            string tokenCondition = string.Join(" AND ", normalizedQuery
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(token => $"search_text LIKE '%{GeoParquetSql.EscapeSqlLiteral(token)}%'"));
+            if (string.IsNullOrWhiteSpace(tokenCondition))
+            {
+                tokenCondition = "FALSE";
+            }
+
+            string extentFilter = string.Empty;
+            if (extent != null)
+            {
+                string xMinStr = extent.XMin.ToString("G", CultureInfo.InvariantCulture);
+                string yMinStr = extent.YMin.ToString("G", CultureInfo.InvariantCulture);
+                string xMaxStr = extent.XMax.ToString("G", CultureInfo.InvariantCulture);
+                string yMaxStr = extent.YMax.ToString("G", CultureInfo.InvariantCulture);
+
+                if (availableColumns.Contains("bbox"))
+                {
+                    extentFilter = $@"
+                        AND bbox.xmin <= {xMaxStr}
+                        AND bbox.xmax >= {xMinStr}
+                        AND bbox.ymin <= {yMaxStr}
+                        AND bbox.ymax >= {yMinStr}";
+                }
+                else
+                {
+                    string extentPolygon = $"ST_GeomFromText('POLYGON(({xMinStr} {yMinStr}, {xMaxStr} {yMinStr}, {xMaxStr} {yMaxStr}, {xMinStr} {yMaxStr}, {xMinStr} {yMinStr}))')";
+                    extentFilter = $@" AND ST_Intersects(geometry, {extentPolygon})";
+                }
+            }
+
+            string searchSql = $@"
+                WITH prepared AS (
+                    SELECT
+                        trim(concat_ws(', ',
+                            nullif(trim(concat_ws(' ', nullif({numberExpr}, ''), nullif({streetExpr}, ''), nullif({placeNameExpr}, ''))), ''),
+                            nullif({localityExpr}, ''),
+                            nullif({regionExpr}, ''),
+                            nullif({postalExpr}, ''),
+                            nullif({countryExpr}, '')
+                        )) AS display_label,
+                        CAST(ST_X(geometry) AS DOUBLE) AS longitude,
+                        CAST(ST_Y(geometry) AS DOUBLE) AS latitude,
+                        lower(trim(concat_ws(' ',
+                            nullif({numberExpr}, ''),
+                            nullif({streetExpr}, ''),
+                            nullif({placeNameExpr}, ''),
+                            nullif({categoryExpr}, ''),
+                            nullif({localityExpr}, ''),
+                            nullif({regionExpr}, ''),
+                            nullif({postalExpr}, ''),
+                            nullif({countryExpr}, '')
+                        ))) AS search_text
+                    FROM read_parquet('{escapedPath}', hive_partitioning=1)
+                    WHERE geometry IS NOT NULL
+                    {extentFilter}
+                ),
+                ranked AS (
+                    SELECT
+                        display_label,
+                        longitude,
+                        latitude,
+                        CASE
+                            WHEN search_text = '{escapedQuery}' THEN 300 + {sourceBias}
+                            WHEN search_text LIKE '{escapedQuery}%' THEN 220 + {sourceBias}
+                            WHEN search_text LIKE '%{escapedQuery}%' THEN 170 + {sourceBias}
+                            WHEN {tokenCondition} THEN 120 + {sourceBias}
+                            ELSE 0
+                        END AS score
+                    FROM prepared
+                    WHERE search_text LIKE '%{escapedQuery}%'
+                       OR ({tokenCondition})
+                )
+                SELECT
+                    display_label,
+                    longitude,
+                    latitude,
+                    '{escapedSourceType}' AS source_type,
+                    CASE
+                        WHEN score >= 300 THEN 'exact'
+                        WHEN score >= 200 THEN 'prefix'
+                        WHEN score >= 150 THEN 'contains'
+                        ELSE 'token'
+                    END AS match_tier,
+                    score
+                FROM ranked
+                WHERE score > 0
+                  AND display_label IS NOT NULL
+                  AND display_label <> ''
+                ORDER BY score DESC, display_label
+                LIMIT {safeLimit};";
+
+            command.CommandText = searchSql;
+            using var resultReader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await resultReader.ReadAsync(cancellationToken))
+            {
+                int score = resultReader.IsDBNull(5) ? 0 : Convert.ToInt32(resultReader.GetValue(5), CultureInfo.InvariantCulture);
+                candidates.Add(new GeocodeCandidate
+                {
+                    DisplayLabel = resultReader.IsDBNull(0) ? string.Empty : resultReader.GetString(0),
+                    Longitude = resultReader.IsDBNull(1) ? 0 : Convert.ToDouble(resultReader.GetValue(1), CultureInfo.InvariantCulture),
+                    Latitude = resultReader.IsDBNull(2) ? 0 : Convert.ToDouble(resultReader.GetValue(2), CultureInfo.InvariantCulture),
+                    SourceType = resultReader.IsDBNull(3) ? "Unknown" : resultReader.GetString(3),
+                    MatchTier = resultReader.IsDBNull(4) ? "token" : resultReader.GetString(4),
+                    Score = score,
+                    ConfidenceTier = score >= 280 ? "High" : score >= 190 ? "Medium" : "Low"
+                });
+            }
+
+            return candidates;
+        }
+    }
+}

--- a/Services/GeocoderEngine.cs
+++ b/Services/GeocoderEngine.cs
@@ -98,8 +98,14 @@ namespace DuckDBGeoparquet.Services
             string regionExpr = FirstExistingExpression(availableColumns, "region", "state", "province", "admin1");
             string postalExpr = FirstExistingExpression(availableColumns, "postcode", "postal_code", "zip");
             string countryExpr = FirstExistingExpression(availableColumns, "country", "country_code");
-            string placeNameExpr = FirstExistingExpression(availableColumns, "name", "name_primary", "names", "brand");
-            string categoryExpr = FirstExistingExpression(availableColumns, "category", "class", "subtype", "kind");
+            // Overture 'names'/'categories' are structs; casting the whole
+            // struct produced JSON-ish display labels — use the primary member.
+            string placeNameExpr = availableColumns.Contains("names")
+                ? "CAST(names.primary AS VARCHAR)"
+                : FirstExistingExpression(availableColumns, "name", "name_primary", "brand");
+            string categoryExpr = availableColumns.Contains("categories")
+                ? "CAST(categories.primary AS VARCHAR)"
+                : FirstExistingExpression(availableColumns, "category", "class", "subtype", "kind");
 
             string tokenCondition = string.Join(" AND ", normalizedQuery
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)

--- a/Services/OvertureGeocoderService.cs
+++ b/Services/OvertureGeocoderService.cs
@@ -1,5 +1,6 @@
 using ArcGIS.Core.Geometry;
 using ArcGIS.Desktop.Core;
+using ArcGIS.Desktop.Mapping;
 using DuckDBGeoparquet.Models;
 using static DuckDBGeoparquet.Models.AddinConstants;
 using System;
@@ -46,6 +47,16 @@ namespace DuckDBGeoparquet.Services
                 return [];
             }
 
+            if (PreferLocatorSearch && IsLocatorReady())
+            {
+                var locatorCandidates = await TryLocatorSearchAsync(query, roiExtent, maxResults);
+                if (locatorCandidates.Count > 0)
+                {
+                    return locatorCandidates;
+                }
+                // No locator hits — fall through to the local DuckDB search.
+            }
+
             string addressParquetGlob = ResolveParquetGlobPath("address");
             string placeParquetGlob = ResolveParquetGlobPath("place");
             if (string.IsNullOrWhiteSpace(addressParquetGlob) && string.IsNullOrWhiteSpace(placeParquetGlob))
@@ -88,6 +99,74 @@ namespace DuckDBGeoparquet.Services
         public async Task<LocatorBuildResult> BuildLocatorAsync(bool forceRebuild)
         {
             return await _locatorBuildService.BuildOrRebuildLocatorAsync(forceRebuild);
+        }
+
+        /// <summary>
+        /// Searches the map's registered locator providers (including the
+        /// built hybrid locator) via LocatorManager.GeocodeAsync. Returns an
+        /// empty list on any failure so callers fall back to the local
+        /// DuckDB search.
+        /// </summary>
+        private static async Task<List<GeocodeCandidate>> TryLocatorSearchAsync(string query, Envelope roiExtent, int maxResults)
+        {
+            var candidates = new List<GeocodeCandidate>();
+            try
+            {
+                var mapView = MapView.Active;
+                if (mapView == null)
+                {
+                    return candidates;
+                }
+
+                var results = await mapView.LocatorManager.GeocodeAsync(query.Trim(), false, false);
+                if (results == null)
+                {
+                    return candidates;
+                }
+
+                foreach (var result in results)
+                {
+                    var location = result.DisplayLocation;
+                    if (location == null)
+                    {
+                        continue;
+                    }
+
+                    MapPoint wgsPoint = location;
+                    if (location.SpatialReference != null && location.SpatialReference.Wkid != 4326)
+                    {
+                        wgsPoint = GeometryEngine.Instance.Project(location, SpatialReferences.WGS84) as MapPoint ?? location;
+                    }
+
+                    if (roiExtent != null &&
+                        (wgsPoint.X < roiExtent.XMin || wgsPoint.X > roiExtent.XMax ||
+                         wgsPoint.Y < roiExtent.YMin || wgsPoint.Y > roiExtent.YMax))
+                    {
+                        continue;
+                    }
+
+                    int score = (int)Math.Round(result.Score);
+                    candidates.Add(new GeocodeCandidate
+                    {
+                        DisplayLabel = result.Label,
+                        Longitude = wgsPoint.X,
+                        Latitude = wgsPoint.Y,
+                        SourceType = "Locator",
+                        MatchTier = "locator",
+                        Score = score,
+                        ConfidenceTier = score >= 90 ? "High" : score >= 75 ? "Medium" : "Low"
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Locator search failed; falling back to local search: {ex.Message}");
+            }
+
+            return candidates
+                .OrderByDescending(c => c.Score)
+                .Take(Math.Clamp(maxResults, 1, 100))
+                .ToList();
         }
 
         private static string NormalizeQuery(string value)

--- a/Services/OvertureGeocoderService.cs
+++ b/Services/OvertureGeocoderService.cs
@@ -86,6 +86,17 @@ namespace DuckDBGeoparquet.Services
                 .ToList();
         }
 
+        /// <summary>
+        /// Geocodes a single query and returns the best candidate (or null).
+        /// Used for file geocoding; goes through the same pipeline as
+        /// interactive search, so it honors PreferLocatorSearch.
+        /// </summary>
+        public async Task<GeocodeCandidate> GeocodeBestAsync(string query, CancellationToken cancellationToken = default)
+        {
+            var results = await SearchAsync(query, null, 1, cancellationToken);
+            return results.FirstOrDefault();
+        }
+
         public bool IsLocatorReady()
         {
             return _locatorBuildService.IsLocatorReady();

--- a/Services/OvertureGeocoderService.cs
+++ b/Services/OvertureGeocoderService.cs
@@ -41,7 +41,7 @@ namespace DuckDBGeoparquet.Services
         {
             await InitializeAsync();
 
-            string normalizedQuery = NormalizeQuery(query);
+            string normalizedQuery = GeocodeTextNormalizer.NormalizeForSearch(query);
             if (string.IsNullOrWhiteSpace(normalizedQuery))
             {
                 return [];
@@ -178,19 +178,6 @@ namespace DuckDBGeoparquet.Services
                 .OrderByDescending(c => c.Score)
                 .Take(Math.Clamp(maxResults, 1, 100))
                 .ToList();
-        }
-
-        private static string NormalizeQuery(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return string.Empty;
-            }
-
-            return string.Join(" ", value
-                .Trim()
-                .ToLowerInvariant()
-                .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         }
 
         private static string ResolveParquetGlobPath(string dataType)

--- a/Services/OvertureGeocoderService.cs
+++ b/Services/OvertureGeocoderService.cs
@@ -37,7 +37,7 @@ namespace DuckDBGeoparquet.Services
             _isInitialized = true;
         }
 
-        public async Task<List<GeocodeCandidate>> SearchAsync(string query, Envelope roiExtent = null, int maxResults = 25, CancellationToken cancellationToken = default)
+        public async Task<List<GeocodeCandidate>> SearchAsync(string query, Envelope searchExtent = null, int maxResults = 25, CancellationToken cancellationToken = default)
         {
             await InitializeAsync();
 
@@ -49,7 +49,7 @@ namespace DuckDBGeoparquet.Services
 
             if (PreferLocatorSearch && IsLocatorReady())
             {
-                var locatorCandidates = await TryLocatorSearchAsync(query, roiExtent, maxResults);
+                var locatorCandidates = await TryLocatorSearchAsync(query, searchExtent, maxResults);
                 if (locatorCandidates.Count > 0)
                 {
                     return locatorCandidates;
@@ -69,13 +69,13 @@ namespace DuckDBGeoparquet.Services
 
             if (!string.IsNullOrWhiteSpace(addressParquetGlob))
             {
-                var addressCandidates = await _dataProcessor.SearchAddressCandidatesAsync(addressParquetGlob, normalizedQuery, roiExtent == null ? null : new ExtentBounds(roiExtent.XMin, roiExtent.YMin, roiExtent.XMax, roiExtent.YMax), perSourceLimit, cancellationToken);
+                var addressCandidates = await _dataProcessor.SearchAddressCandidatesAsync(addressParquetGlob, normalizedQuery, searchExtent == null ? null : new ExtentBounds(searchExtent.XMin, searchExtent.YMin, searchExtent.XMax, searchExtent.YMax), perSourceLimit, cancellationToken);
                 merged.AddRange(addressCandidates);
             }
 
             if (!string.IsNullOrWhiteSpace(placeParquetGlob))
             {
-                var placeCandidates = await _dataProcessor.SearchPlaceCandidatesAsync(placeParquetGlob, normalizedQuery, roiExtent == null ? null : new ExtentBounds(roiExtent.XMin, roiExtent.YMin, roiExtent.XMax, roiExtent.YMax), perSourceLimit, cancellationToken);
+                var placeCandidates = await _dataProcessor.SearchPlaceCandidatesAsync(placeParquetGlob, normalizedQuery, searchExtent == null ? null : new ExtentBounds(searchExtent.XMin, searchExtent.YMin, searchExtent.XMax, searchExtent.YMax), perSourceLimit, cancellationToken);
                 merged.AddRange(placeCandidates);
             }
 
@@ -118,7 +118,7 @@ namespace DuckDBGeoparquet.Services
         /// empty list on any failure so callers fall back to the local
         /// DuckDB search.
         /// </summary>
-        private static async Task<List<GeocodeCandidate>> TryLocatorSearchAsync(string query, Envelope roiExtent, int maxResults)
+        private static async Task<List<GeocodeCandidate>> TryLocatorSearchAsync(string query, Envelope searchExtent, int maxResults)
         {
             var candidates = new List<GeocodeCandidate>();
             try
@@ -149,9 +149,9 @@ namespace DuckDBGeoparquet.Services
                         wgsPoint = GeometryEngine.Instance.Project(location, SpatialReferences.WGS84) as MapPoint ?? location;
                     }
 
-                    if (roiExtent != null &&
-                        (wgsPoint.X < roiExtent.XMin || wgsPoint.X > roiExtent.XMax ||
-                         wgsPoint.Y < roiExtent.YMin || wgsPoint.Y > roiExtent.YMax))
+                    if (searchExtent != null &&
+                        (wgsPoint.X < searchExtent.XMin || wgsPoint.X > searchExtent.XMax ||
+                         wgsPoint.Y < searchExtent.YMin || wgsPoint.Y > searchExtent.YMax))
                     {
                         continue;
                     }

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -271,11 +271,29 @@ namespace DuckDBGeoparquet.Services
             string metadataPath = GetMetadataPath();
             File.WriteAllText(metadataPath, JsonSerializer.Serialize(metadata, new JsonSerializerOptions { WriteIndented = true }));
 
+            // Register the composite locator with the project so it becomes a
+            // locator provider — LocatorManager.GeocodeAsync only searches
+            // registered providers.
+            string registrationNote = string.Empty;
+            try
+            {
+                bool added = await QueuedTask.Run(() =>
+                {
+                    var locatorItem = ItemFactory.Instance.Create(compositeLocatorPath) as IProjectItem;
+                    return locatorItem != null && Project.Current.AddItem(locatorItem);
+                });
+                registrationNote = added ? " Locator registered with the project." : string.Empty;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Could not register locator with project: {ex.Message}");
+            }
+
             return new LocatorBuildResult
             {
                 Succeeded = true,
                 LocatorPath = compositeLocatorPath,
-                Message = $"Hybrid locator built: {Path.GetFileName(compositeLocatorPath)}" +
+                Message = $"Hybrid locator built: {Path.GetFileName(compositeLocatorPath)}{registrationNote}" +
                     (string.IsNullOrWhiteSpace(addressBuildNotes) ? string.Empty : $" {addressBuildNotes}") +
                     (string.IsNullOrWhiteSpace(placeBuildNotes) ? string.Empty : $" {placeBuildNotes}")
             };

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -192,13 +192,15 @@ namespace DuckDBGeoparquet.Services
 
             if (!addressBuilt)
             {
-                string fallbackAddressField = SelectFieldName(addressFields, "street", "street_name", "road", "name");
+                string fallbackAddressField = SelectFieldName(addressFields,
+                    "street", "street_name", "road", "name", "names_primary", "full_address", "address");
                 if (string.IsNullOrWhiteSpace(fallbackAddressField))
                 {
                     return new LocatorBuildResult
                     {
                         Succeeded = false,
-                        Message = "Address locator mapping could not find a usable street/name field."
+                        Message = "Address locator mapping could not find a usable street/name field. " +
+                                  $"Available fields: {string.Join(", ", addressFields.OrderBy(f => f))}"
                     };
                 }
 
@@ -232,13 +234,18 @@ namespace DuckDBGeoparquet.Services
 
             if (!placeBuilt)
             {
-                string fallbackPlaceField = SelectFieldName(placeFields, "name", "name_primary", "brand", "category");
+                // Overture 'names'/'categories' are nested structs that the
+                // parquet→GDB conversion flattens (e.g. names_primary).
+                string fallbackPlaceField = SelectFieldName(placeFields,
+                    "name", "name_primary", "names_primary", "primary_name", "names",
+                    "brand", "category", "categories_primary", "category_primary", "categories");
                 if (string.IsNullOrWhiteSpace(fallbackPlaceField))
                 {
                     return new LocatorBuildResult
                     {
                         Succeeded = false,
-                        Message = "Place locator mapping could not find a usable name/category field."
+                        Message = "Place locator mapping could not find a usable name/category field. " +
+                                  $"Available fields: {string.Join(", ", placeFields.OrderBy(f => f))}"
                     };
                 }
 

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -202,10 +202,10 @@ namespace DuckDBGeoparquet.Services
                     };
                 }
 
-                // The search-fields parameter is a mapping table: the
-                // locator's 'Name' role paired with the input field. A bare
-                // field name fails with ERROR 003057.
-                var addressLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [addressFc, $"Name {fallbackAddressField}", addressLocatorPath]);
+                // The search-fields parameter is a mapping table entry in the
+                // form "*Name <inputField> VISIBLE NONE" (per Esri's tool
+                // examples); anything else fails with ERROR 003057.
+                var addressLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [addressFc, $"*Name {fallbackAddressField} VISIBLE NONE", addressLocatorPath]);
                 if (addressLocatorResult.IsFailed)
                 {
                     return Fail("Failed to create address locator after role mapping fallback.", addressLocatorResult);
@@ -242,7 +242,7 @@ namespace DuckDBGeoparquet.Services
                     };
                 }
 
-                var placeLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [placeFc, $"Name {fallbackPlaceField}", placeLocatorPath]);
+                var placeLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [placeFc, $"*Name {fallbackPlaceField} VISIBLE NONE", placeLocatorPath]);
                 if (placeLocatorResult.IsFailed)
                 {
                     return Fail("Failed to create place locator after role mapping fallback.", placeLocatorResult);

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -258,38 +258,53 @@ namespace DuckDBGeoparquet.Services
                 placeBuilt = true;
             }
 
+            // Paths contain spaces (e.g. 'OneDrive - County of Fresno') and
+            // must be single-quoted or the value-table parser splits them.
+            // The tool's positional parameters are (locators, field_map, output).
             var compositeResult = await RunGpToolAsync(
                 "geocoding.CreateCompositeAddressLocator",
-                [$"{addressLocatorPath} Address;{placeLocatorPath} Place", compositeLocatorPath]);
+                [$"'{addressLocatorPath}' Address;'{placeLocatorPath}' Place", "", compositeLocatorPath]);
 
-            if (compositeResult.IsFailed)
-            {
-                return Fail("Failed to create composite locator from address/place locators.", compositeResult);
-            }
+            bool compositeBuilt = !compositeResult.IsFailed;
+            string compositeNote = compositeBuilt
+                ? string.Empty
+                : $" Composite creation failed ({GpMessages(compositeResult)}); the address and place locators are registered individually instead.";
 
             var metadata = new LocatorBuildMetadata
             {
                 ReleaseFolderName = latestReleaseDir.Name,
-                LocatorPath = compositeLocatorPath,
-                CompositeLocatorPath = compositeLocatorPath,
+                LocatorPath = compositeBuilt ? compositeLocatorPath : addressLocatorPath,
+                CompositeLocatorPath = compositeBuilt ? compositeLocatorPath : null,
                 LastBuiltUtc = DateTime.UtcNow
             };
 
             string metadataPath = GetMetadataPath();
             File.WriteAllText(metadataPath, JsonSerializer.Serialize(metadata, new JsonSerializerOptions { WriteIndented = true }));
 
-            // Register the composite locator with the project so it becomes a
-            // locator provider — LocatorManager.GeocodeAsync only searches
-            // registered providers.
+            // Register the locator(s) with the project so they become locator
+            // providers — LocatorManager.GeocodeAsync only searches
+            // registered providers. If the composite exists, one registration
+            // covers both; otherwise register address and place separately.
             string registrationNote = string.Empty;
             try
             {
-                bool added = await QueuedTask.Run(() =>
+                string[] locatorsToRegister = compositeBuilt
+                    ? [compositeLocatorPath]
+                    : [addressLocatorPath, placeLocatorPath];
+                int registered = await QueuedTask.Run(() =>
                 {
-                    var locatorItem = ItemFactory.Instance.Create(compositeLocatorPath) as IProjectItem;
-                    return locatorItem != null && Project.Current.AddItem(locatorItem);
+                    int count = 0;
+                    foreach (var path in locatorsToRegister)
+                    {
+                        var locatorItem = ItemFactory.Instance.Create(path) as IProjectItem;
+                        if (locatorItem != null && Project.Current.AddItem(locatorItem))
+                        {
+                            count++;
+                        }
+                    }
+                    return count;
                 });
-                registrationNote = added ? " Locator registered with the project." : string.Empty;
+                registrationNote = registered > 0 ? $" {registered} locator(s) registered with the project." : string.Empty;
             }
             catch (Exception ex)
             {
@@ -299,8 +314,8 @@ namespace DuckDBGeoparquet.Services
             return new LocatorBuildResult
             {
                 Succeeded = true,
-                LocatorPath = compositeLocatorPath,
-                Message = $"Hybrid locator built: {Path.GetFileName(compositeLocatorPath)}{registrationNote}" +
+                LocatorPath = metadata.LocatorPath,
+                Message = $"Hybrid locator built: {Path.GetFileName(metadata.LocatorPath)}{registrationNote}{compositeNote}" +
                     (string.IsNullOrWhiteSpace(addressBuildNotes) ? string.Empty : $" {addressBuildNotes}") +
                     (string.IsNullOrWhiteSpace(placeBuildNotes) ? string.Empty : $" {placeBuildNotes}")
             };

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -1,4 +1,5 @@
 using ArcGIS.Core.Data;
+using ArcGIS.Desktop.Catalog;
 using ArcGIS.Desktop.Core;
 using ArcGIS.Desktop.Core.Geoprocessing;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
@@ -109,38 +110,24 @@ namespace DuckDBGeoparquet.Services
             Directory.CreateDirectory(locatorRoot);
             string scratchGdbFolder = Path.Combine(locatorRoot, "scratch");
             Directory.CreateDirectory(scratchGdbFolder);
-            string scratchGdbPath = Path.Combine(scratchGdbFolder, "overture_locator_input.gdb");
 
-            if (Directory.Exists(scratchGdbPath) && forceRebuild)
-            {
-                try
-                {
-                    Directory.Delete(scratchGdbPath, true);
-                }
-                catch (Exception ex)
-                {
-                    // Continuing into a half-cleared, locked geodatabase makes
-                    // the export steps fail confusingly later — stop here with
-                    // an actionable message instead.
-                    System.Diagnostics.Debug.WriteLine($"Could not clear scratch geodatabase: {ex.Message}");
-                    return new LocatorBuildResult
-                    {
-                        Succeeded = false,
-                        Message = "The previous locator scratch geodatabase is locked by another process " +
-                                  "(usually ArcGIS Pro itself — a locator registered in the project or a layer " +
-                                  "referencing it). Remove those references, restart ArcGIS Pro, and rebuild. " +
-                                  $"Locked path: {scratchGdbPath} ({ex.Message})"
-                    };
-                }
-            }
+            // A feature locator holds a live reference to its input feature
+            // classes, so once registered it locks the scratch geodatabase and
+            // its own .loc files — the previous build's outputs can never be
+            // deleted or overwritten. Unregister the old Overture locators to
+            // release those locks, then use fresh timestamped names so this
+            // build can never be blocked by a still-locked predecessor.
+            await UnregisterProjectLocatorsAsync(locatorRoot);
+            CleanupOldLocatorArtifacts(locatorRoot, scratchGdbFolder);
 
-            if (!Directory.Exists(scratchGdbPath))
+            string buildStamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+            string scratchGdbName = $"locator_input_{buildStamp}.gdb";
+            string scratchGdbPath = Path.Combine(scratchGdbFolder, scratchGdbName);
+
+            var createGdbResult = await RunGpToolAsync("management.CreateFileGDB", [scratchGdbFolder, scratchGdbName]);
+            if (createGdbResult.IsFailed)
             {
-                var createGdbResult = await RunGpToolAsync("management.CreateFileGDB", [scratchGdbFolder, "overture_locator_input.gdb"]);
-                if (createGdbResult.IsFailed)
-                {
-                    return Fail("Failed to create scratch geodatabase.", createGdbResult);
-                }
+                return Fail("Failed to create scratch geodatabase.", createGdbResult);
             }
 
             string addressFc = Path.Combine(scratchGdbPath, "address_points");
@@ -158,14 +145,9 @@ namespace DuckDBGeoparquet.Services
                 return Fail("Failed to export place parquet to feature class.", exportPlaceResult);
             }
 
-            string addressLocatorPath = Path.Combine(locatorRoot, "OvertureAddress.loc");
-            string placeLocatorPath = Path.Combine(locatorRoot, "OverturePlace.loc");
-            string compositeLocatorPath = Path.Combine(locatorRoot, "OvertureHybrid.loc");
-
-            // Locator tools do NOT honor the overwriteOutput environment, so a
-            // previous build's .loc outputs cause ERROR 000725. Delete them
-            // first so the build is idempotent for both Build and Rebuild.
-            await CleanupExistingLocatorsAsync(addressLocatorPath, placeLocatorPath, compositeLocatorPath);
+            string addressLocatorPath = Path.Combine(locatorRoot, $"OvertureAddress_{buildStamp}.loc");
+            string placeLocatorPath = Path.Combine(locatorRoot, $"OverturePlace_{buildStamp}.loc");
+            string compositeLocatorPath = Path.Combine(locatorRoot, $"OvertureHybrid_{buildStamp}.loc");
 
             var addressFields = await GetFeatureClassFieldNamesAsync(addressFc);
             var placeFields = await GetFeatureClassFieldNamesAsync(placeFc);
@@ -340,32 +322,68 @@ namespace DuckDBGeoparquet.Services
         }
 
         /// <summary>
-        /// Removes any previously built locator outputs before a rebuild.
-        /// Locator geoprocessing tools ignore the overwrite environment, so a
-        /// leftover .loc dataset otherwise fails with ERROR 000725. Uses the
-        /// Delete GP tool, which removes the locator's companion files too.
+        /// Unregisters this add-in's previously built locators (any locator
+        /// project item under <paramref name="locatorRoot"/>) so the files
+        /// they reference are released and can be cleaned up.
         /// </summary>
-        private static async Task CleanupExistingLocatorsAsync(params string[] locatorPaths)
+        private static async Task UnregisterProjectLocatorsAsync(string locatorRoot)
         {
-            foreach (var path in locatorPaths)
+            try
             {
-                if (!File.Exists(path) && !Directory.Exists(path))
+                string rootFull = Path.GetFullPath(locatorRoot);
+                await QueuedTask.Run(() =>
                 {
-                    continue;
-                }
-                try
-                {
-                    var result = await RunGpToolAsync("management.Delete", [path]);
-                    if (result.IsFailed)
+                    foreach (var item in Project.Current.GetItems<LocatorsConnectionProjectItem>().ToList())
                     {
-                        System.Diagnostics.Debug.WriteLine($"Could not delete existing locator {path}: {GpMessages(result)}");
+                        if (string.IsNullOrWhiteSpace(item.Path))
+                        {
+                            continue;
+                        }
+                        if (Path.GetFullPath(item.Path).StartsWith(rootFull, StringComparison.OrdinalIgnoreCase))
+                        {
+                            Project.Current.RemoveItem(item as IProjectItem);
+                        }
                     }
-                }
-                catch (Exception ex)
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Unregister project locators skipped: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Best-effort removal of prior builds' locator files and scratch
+        /// geodatabases. Anything still locked (e.g. a locator Pro hasn't
+        /// released yet) is left for a future run; the current build uses
+        /// fresh timestamped names, so leftovers never block it.
+        /// </summary>
+        private static void CleanupOldLocatorArtifacts(string locatorRoot, string scratchGdbFolder)
+        {
+            try
+            {
+                foreach (var loc in Directory.EnumerateFiles(locatorRoot, "Overture*.loc"))
                 {
-                    System.Diagnostics.Debug.WriteLine($"Delete existing locator {path} threw: {ex.Message}");
+                    TryDeleteFile(loc);
+                    TryDeleteFile(loc + ".xml");
+                    TryDeleteFile(Path.ChangeExtension(loc, ".loz"));
+                }
+                foreach (var gdb in Directory.EnumerateDirectories(scratchGdbFolder, "*.gdb"))
+                {
+                    try { Directory.Delete(gdb, true); }
+                    catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Leaving locked scratch gdb {gdb}: {ex.Message}"); }
                 }
             }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Old locator artifact cleanup skipped: {ex.Message}");
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try { if (File.Exists(path)) File.Delete(path); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Leaving locked file {path}: {ex.Message}"); }
         }
 
         private static async Task<IGPResult> RunGpToolAsync(string toolName, IEnumerable<object> values)

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -186,7 +186,7 @@ namespace DuckDBGeoparquet.Services
                 }
                 else
                 {
-                    addressBuildNotes = "Address role mapping failed; falling back to feature locator.";
+                    addressBuildNotes = $"Address role mapping failed; falling back to feature locator. ({GpMessages(addressCreateLocatorResult)})";
                 }
             }
 
@@ -202,7 +202,10 @@ namespace DuckDBGeoparquet.Services
                     };
                 }
 
-                var addressLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [addressFc, fallbackAddressField, addressLocatorPath]);
+                // The search-fields parameter is a mapping table: the
+                // locator's 'Name' role paired with the input field. A bare
+                // field name fails with ERROR 003057.
+                var addressLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [addressFc, $"Name {fallbackAddressField}", addressLocatorPath]);
                 if (addressLocatorResult.IsFailed)
                 {
                     return Fail("Failed to create address locator after role mapping fallback.", addressLocatorResult);
@@ -223,7 +226,7 @@ namespace DuckDBGeoparquet.Services
                 }
                 else
                 {
-                    placeBuildNotes = "POI role mapping failed; falling back to feature locator.";
+                    placeBuildNotes = $"POI role mapping failed; falling back to feature locator. ({GpMessages(placeCreateLocatorResult)})";
                 }
             }
 
@@ -239,7 +242,7 @@ namespace DuckDBGeoparquet.Services
                     };
                 }
 
-                var placeLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [placeFc, fallbackPlaceField, placeLocatorPath]);
+                var placeLocatorResult = await RunGpToolAsync("geocoding.CreateFeatureLocator", [placeFc, $"Name {fallbackPlaceField}", placeLocatorPath]);
                 if (placeLocatorResult.IsFailed)
                 {
                     return Fail("Failed to create place locator after role mapping fallback.", placeLocatorResult);
@@ -277,6 +280,9 @@ namespace DuckDBGeoparquet.Services
                     (string.IsNullOrWhiteSpace(placeBuildNotes) ? string.Empty : $" {placeBuildNotes}")
             };
         }
+
+        private static string GpMessages(IGPResult result) =>
+            result == null ? string.Empty : string.Join(" | ", result.Messages.Select(m => m.Text));
 
         private static LocatorBuildResult Fail(string message, IGPResult result)
         {

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -87,8 +87,15 @@ namespace DuckDBGeoparquet.Services
                 };
             }
 
-            string addressParquet = Directory.EnumerateFiles(addressDir, "*.parquet").FirstOrDefault();
-            string placeParquet = Directory.EnumerateFiles(placeDir, "*.parquet").FirstOrDefault();
+            // Load cleanups skip locked files, so these folders can hold
+            // several session-stamped parquet files — build from the newest.
+            static string NewestParquet(string dir) => Directory
+                .EnumerateFiles(dir, "*.parquet")
+                .OrderByDescending(File.GetLastWriteTimeUtc)
+                .FirstOrDefault();
+
+            string addressParquet = NewestParquet(addressDir);
+            string placeParquet = NewestParquet(placeDir);
             if (string.IsNullOrWhiteSpace(addressParquet) || string.IsNullOrWhiteSpace(placeParquet))
             {
                 return new LocatorBuildResult
@@ -112,7 +119,18 @@ namespace DuckDBGeoparquet.Services
                 }
                 catch (Exception ex)
                 {
+                    // Continuing into a half-cleared, locked geodatabase makes
+                    // the export steps fail confusingly later — stop here with
+                    // an actionable message instead.
                     System.Diagnostics.Debug.WriteLine($"Could not clear scratch geodatabase: {ex.Message}");
+                    return new LocatorBuildResult
+                    {
+                        Succeeded = false,
+                        Message = "The previous locator scratch geodatabase is locked by another process " +
+                                  "(usually ArcGIS Pro itself — a locator registered in the project or a layer " +
+                                  "referencing it). Remove those references, restart ArcGIS Pro, and rebuild. " +
+                                  $"Locked path: {scratchGdbPath} ({ex.Message})"
+                    };
                 }
             }
 

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -5,6 +5,7 @@ using ArcGIS.Desktop.Core.Geoprocessing;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -162,6 +162,11 @@ namespace DuckDBGeoparquet.Services
             string placeLocatorPath = Path.Combine(locatorRoot, "OverturePlace.loc");
             string compositeLocatorPath = Path.Combine(locatorRoot, "OvertureHybrid.loc");
 
+            // Locator tools do NOT honor the overwriteOutput environment, so a
+            // previous build's .loc outputs cause ERROR 000725. Delete them
+            // first so the build is idempotent for both Build and Rebuild.
+            await CleanupExistingLocatorsAsync(addressLocatorPath, placeLocatorPath, compositeLocatorPath);
+
             var addressFields = await GetFeatureClassFieldNamesAsync(addressFc);
             var placeFields = await GetFeatureClassFieldNamesAsync(placeFc);
 
@@ -332,6 +337,35 @@ namespace DuckDBGeoparquet.Services
                 Succeeded = false,
                 Message = $"{message}{(string.IsNullOrWhiteSpace(gpMessages) ? string.Empty : $"{Environment.NewLine}{gpMessages}")}"
             };
+        }
+
+        /// <summary>
+        /// Removes any previously built locator outputs before a rebuild.
+        /// Locator geoprocessing tools ignore the overwrite environment, so a
+        /// leftover .loc dataset otherwise fails with ERROR 000725. Uses the
+        /// Delete GP tool, which removes the locator's companion files too.
+        /// </summary>
+        private static async Task CleanupExistingLocatorsAsync(params string[] locatorPaths)
+        {
+            foreach (var path in locatorPaths)
+            {
+                if (!File.Exists(path) && !Directory.Exists(path))
+                {
+                    continue;
+                }
+                try
+                {
+                    var result = await RunGpToolAsync("management.Delete", [path]);
+                    if (result.IsFailed)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Could not delete existing locator {path}: {GpMessages(result)}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Delete existing locator {path} threw: {ex.Message}");
+                }
+            }
         }
 
         private static async Task<IGPResult> RunGpToolAsync(string toolName, IEnumerable<object> values)

--- a/Services/OvertureLocatorBuildService.cs
+++ b/Services/OvertureLocatorBuildService.cs
@@ -294,11 +294,15 @@ namespace DuckDBGeoparquet.Services
             {
                 var parameters = Geoprocessing.MakeValueArray(values.ToArray());
                 var environment = Geoprocessing.MakeEnvironmentArray(overwriteoutput: true);
+                // GPExecuteToolFlags.Default adds tool outputs to the active
+                // map — the staged scratch feature classes would appear as
+                // layers AND hold locks on the scratch geodatabase, breaking
+                // every subsequent rebuild.
                 return await Geoprocessing.ExecuteToolAsync(
                     toolName,
                     parameters,
                     environment,
-                    flags: GPExecuteToolFlags.Default);
+                    flags: GPExecuteToolFlags.None);
             });
         }
 

--- a/Views/OvertureGeocoderDockpane.xaml
+++ b/Views/OvertureGeocoderDockpane.xaml
@@ -119,11 +119,11 @@
                                 <TextBlock Text="{Binding DisplayLabel}"
                                            TextWrapping="Wrap"
                                            FontWeight="SemiBold"/>
-                                <TextBlock Text="{Binding MatchTier, StringFormat='Match: {0}'}"
+                                <TextBlock Text="{Binding MatchSummary, StringFormat='Match: {0}'}"
                                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
                                 <TextBlock Text="{Binding SourceType, StringFormat='Source: {0}'}"
                                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
-                                <TextBlock Text="{Binding ConfidenceTier, StringFormat='Confidence: {0}'}"
+                                <TextBlock Text="{Binding ConfidenceSummary, StringFormat='Confidence: {0}'}"
                                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
                             </StackPanel>
                         </DataTemplate>

--- a/Views/OvertureGeocoderDockpane.xaml
+++ b/Views/OvertureGeocoderDockpane.xaml
@@ -42,7 +42,7 @@
                 <TextBlock Text="2) Return here, enter an address/place name, then click Search."
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
-                <TextBlock Text="3) Select a result and click Zoom To Selected."
+                <TextBlock Text="3) Click a result to zoom to it, or add all results to the map as a feature class."
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
             </StackPanel>
@@ -143,6 +143,19 @@
                         Width="110"
                         Margin="8,0,0,0"
                         Command="{Binding ClearResultsCommand}"
+                        Style="{DynamicResource Esri_Button}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                <Button Content="Add Results to Map"
+                        Width="130"
+                        Command="{Binding AddResultsToMapCommand}"
+                        Style="{DynamicResource Esri_Button}"
+                        ToolTip="Save the current results as a point feature class in the project geodatabase and add it to the map"/>
+                <Button Content="Geocode File..."
+                        Width="110"
+                        Margin="8,0,0,0"
+                        Command="{Binding GeocodeFileCommand}"
+                        ToolTip="Geocode a CSV of addresses (uses a column named 'address' if present, otherwise the first column) and add the matches to the map"
                         Style="{DynamicResource Esri_Button}" />
             </StackPanel>
             <TextBlock Margin="0,8,0,0"

--- a/Views/OvertureGeocoderDockpane.xaml
+++ b/Views/OvertureGeocoderDockpane.xaml
@@ -36,13 +36,13 @@
                 <TextBlock Text="How to use this geocoder"
                            FontWeight="SemiBold"
                            Margin="0,0,0,4"/>
-                <TextBlock Text="1) Open Overture Maps Data Loader and load at least Addresses and Places for your area."
+                <TextBlock Text="1) Open Overture Maps Data Loader and load at least Addresses and Places."
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
-                <TextBlock Text="2) Return here, enter an address/place name, then click Search."
+                <TextBlock Text="2) Search covers the loaded Overture datasets, not just the current map view."
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
-                <TextBlock Text="3) Click a result to zoom to it, or add all results to the map as a feature class."
+                <TextBlock Text="3) Select one or more candidates to zoom or add selected results to the map."
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"/>
             </StackPanel>
@@ -55,7 +55,8 @@
             </Grid.ColumnDefinitions>
             <TextBox Grid.Column="0"
                      Margin="0,0,8,0"
-                     Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}" />
+                     Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"
+                     KeyDown="SearchTextBox_KeyDown" />
             <Button Grid.Column="1"
                     Content="Search"
                     Width="80"
@@ -106,9 +107,12 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <ListBox Grid.Row="0"
+                <ListBox x:Name="ResultsListBox"
+                         Grid.Row="0"
                          ItemsSource="{Binding Results}"
-                         SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}">
+                         SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
+                         SelectionMode="Extended"
+                         SelectionChanged="ResultsListBox_SelectionChanged">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Margin="0,2,0,4">
@@ -150,7 +154,7 @@
                         Width="130"
                         Command="{Binding AddResultsToMapCommand}"
                         Style="{DynamicResource Esri_Button}"
-                        ToolTip="Save the current results as a point feature class in the project geodatabase and add it to the map"/>
+                        ToolTip="Save selected results, or all results if none are selected, as a point feature class in the project geodatabase and add it to the map"/>
                 <Button Content="Geocode File..."
                         Width="110"
                         Margin="8,0,0,0"

--- a/Views/OvertureGeocoderDockpane.xaml
+++ b/Views/OvertureGeocoderDockpane.xaml
@@ -159,7 +159,7 @@
                         Width="110"
                         Margin="8,0,0,0"
                         Command="{Binding GeocodeFileCommand}"
-                        ToolTip="Geocode a CSV of addresses (uses a column named 'address' if present, otherwise the first column) and add the matches to the map"
+                        ToolTip="Geocode a delimited text file of addresses (auto-detects common address columns such as address, city, state, and ZIP) and add the matches to the map"
                         Style="{DynamicResource Esri_Button}" />
             </StackPanel>
             <TextBlock Margin="0,8,0,0"

--- a/Views/OvertureGeocoderDockpane.xaml.cs
+++ b/Views/OvertureGeocoderDockpane.xaml.cs
@@ -1,4 +1,7 @@
+using System.Linq;
 using System.Windows.Controls;
+using System.Windows.Input;
+using DuckDBGeoparquet.Models;
 
 namespace DuckDBGeoparquet.Views
 {
@@ -7,6 +10,26 @@ namespace DuckDBGeoparquet.Views
         public OvertureGeocoderDockpaneView()
         {
             InitializeComponent();
+        }
+
+        private void ResultsListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (DataContext is OvertureGeocoderDockpaneViewModel viewModel &&
+                sender is ListBox listBox)
+            {
+                viewModel.SetSelectedCandidates(listBox.SelectedItems.Cast<GeocodeCandidate>());
+            }
+        }
+
+        private void SearchTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Return &&
+                DataContext is OvertureGeocoderDockpaneViewModel viewModel &&
+                viewModel.SearchAddressCommand.CanExecute(null))
+            {
+                viewModel.SearchAddressCommand.Execute(null);
+                e.Handled = true;
+            }
         }
     }
 }

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -445,17 +445,26 @@ namespace DuckDBGeoparquet.Views
                 return;
             }
 
+            double lon = SelectedCandidate.Longitude;
+            double lat = SelectedCandidate.Latitude;
+            string label = SelectedCandidate.DisplayLabel;
             try
             {
-                var wgs84 = SpatialReferenceBuilder.CreateSpatialReference(4326);
-                var location = MapPointBuilderEx.CreateMapPoint(SelectedCandidate.Longitude, SelectedCandidate.Latitude, wgs84);
-                var marker = SymbolFactory.Instance.ConstructPointSymbol(ColorFactory.Instance.RedRGB, 11.0, SimpleMarkerStyle.Circle);
+                // Geometry/symbol construction and overlay/zoom must run on the
+                // MCT (QueuedTask), not the UI thread that raised the selection.
+                var overlay = await QueuedTask.Run(() =>
+                {
+                    var wgs84 = SpatialReferenceBuilder.CreateSpatialReference(4326);
+                    var location = MapPointBuilderEx.CreateMapPoint(lon, lat, wgs84);
+                    var marker = SymbolFactory.Instance.ConstructPointSymbol(ColorFactory.Instance.RedRGB, 11.0, SimpleMarkerStyle.Circle);
+                    var handle = mapView.AddOverlay(location, marker.MakeSymbolReference());
+                    mapView.ZoomTo(location);
+                    return handle;
+                });
 
                 _selectionOverlay?.Dispose();
-                _selectionOverlay = mapView.AddOverlay(location, marker.MakeSymbolReference());
-
-                await QueuedTask.Run(() => mapView.ZoomTo(location));
-                StatusText = $"Zoomed to {SelectedCandidate.DisplayLabel}";
+                _selectionOverlay = overlay;
+                StatusText = $"Zoomed to {label}";
             }
             catch (Exception ex)
             {

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -210,10 +210,18 @@ namespace DuckDBGeoparquet.Views
             try
             {
                 var result = await _geocoderService.BuildLocatorAsync(forceRebuild);
-                LocatorStatusText = result.Message;
-                StatusText = result.Succeeded
-                    ? "Hybrid locator build completed."
-                    : "Hybrid locator build failed. See locator status for details.";
+                if (result.Succeeded)
+                {
+                    StatusText = "Hybrid locator build completed.";
+                    RefreshLocatorStatus();
+                }
+                else
+                {
+                    // Keep the failure message visible — RefreshLocatorStatus
+                    // would replace it with the generic "not built yet" text.
+                    LocatorStatusText = result.Message;
+                    StatusText = "Hybrid locator build failed. See locator status for details.";
+                }
             }
             catch (Exception ex)
             {
@@ -225,7 +233,6 @@ namespace DuckDBGeoparquet.Views
                 _isBuildingLocator = false;
                 (BuildLocatorCommand as RelayCommand)?.RaiseCanExecuteChanged();
                 (RebuildLocatorCommand as RelayCommand)?.RaiseCanExecuteChanged();
-                RefreshLocatorStatus();
             }
         }
 

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -23,7 +23,8 @@ namespace DuckDBGeoparquet.Views
     {
         private const string DockPaneId = "DuckDBGeoparquet_Views_OvertureGeocoderDockpane";
         private OvertureGeocoderService _geocoderService;
-        private IDisposable _selectionOverlay;
+        private readonly List<IDisposable> _candidateOverlays = [];
+        private readonly List<IDisposable> _selectionOverlays = [];
         private string _searchQuery;
         private GeocodeCandidate _selectedCandidate;
         private string _statusText = "Load Addresses + Places first in Overture Maps Data Loader, then search here.";
@@ -31,12 +32,14 @@ namespace DuckDBGeoparquet.Views
         private bool _isBuildingLocator;
         private bool _isAddingToMap;
         private bool _isGeocodingFile;
+        private bool _suppressSelectionZoom;
         private bool _useLocatorSearch;
         private string _locatorStatusText = "Locator not built.";
 
         public OvertureGeocoderDockpaneViewModel()
         {
             Results = [];
+            SelectedCandidates = [];
 
             if (DesignerProperties.GetIsInDesignMode(new DependencyObject()))
             {
@@ -52,6 +55,7 @@ namespace DuckDBGeoparquet.Views
                     Score = 300
                 });
                 SelectedCandidate = Results.FirstOrDefault();
+                SelectedCandidates.Add(SelectedCandidate);
                 return;
             }
 
@@ -84,6 +88,7 @@ namespace DuckDBGeoparquet.Views
         }
 
         public ObservableCollection<GeocodeCandidate> Results { get; }
+        public ObservableCollection<GeocodeCandidate> SelectedCandidates { get; }
 
         public string SearchQuery
         {
@@ -104,8 +109,8 @@ namespace DuckDBGeoparquet.Views
             {
                 if (SetProperty(ref _selectedCandidate, value))
                 {
-                    (ZoomToSelectedCommand as RelayCommand)?.RaiseCanExecuteChanged();
-                    if (value != null)
+                    RaiseResultCommandStatesChanged();
+                    if (value != null && !_suppressSelectionZoom)
                     {
                         // Like Pro's Locate pane: clicking a result zooms to it.
                         _ = ZoomToSelectedAsync();
@@ -155,14 +160,55 @@ namespace DuckDBGeoparquet.Views
         {
             _geocoderService = new OvertureGeocoderService();
 
-            SearchAddressCommand = new RelayCommand(async () => await SearchAsync(), () => !_isSearching && !string.IsNullOrWhiteSpace(SearchQuery));
-            ZoomToSelectedCommand = new RelayCommand(async () => await ZoomToSelectedAsync(), () => SelectedCandidate != null);
+            SearchAddressCommand = new RelayCommand(async () => await SearchAsync(), () => !_isSearching && !_isAddingToMap && !_isGeocodingFile && !string.IsNullOrWhiteSpace(SearchQuery));
+            ZoomToSelectedCommand = new RelayCommand(async () => await ZoomToSelectedAsync(), () => GetSelectedCandidatesForAction().Count > 0);
             ClearResultsCommand = new RelayCommand(ClearResults);
-            AddResultsToMapCommand = new RelayCommand(async () => await AddResultsToMapAsync(), () => !_isAddingToMap);
-            GeocodeFileCommand = new RelayCommand(async () => await GeocodeFileAsync(), () => !_isGeocodingFile);
+            AddResultsToMapCommand = new RelayCommand(async () => await AddResultsToMapAsync(), () => !_isSearching && !_isAddingToMap && !_isGeocodingFile && Results.Count > 0);
+            GeocodeFileCommand = new RelayCommand(async () => await GeocodeFileAsync(), () => !_isSearching && !_isAddingToMap && !_isGeocodingFile);
             BuildLocatorCommand = new RelayCommand(async () => await BuildLocatorAsync(false), () => !_isBuildingLocator);
             RebuildLocatorCommand = new RelayCommand(async () => await BuildLocatorAsync(true), () => !_isBuildingLocator);
             RefreshLocatorStatusCommand = new RelayCommand(RefreshLocatorStatus);
+        }
+
+        private void RaiseResultCommandStatesChanged()
+        {
+            (ZoomToSelectedCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (AddResultsToMapCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+
+        private void RaiseFileWorkflowCommandStatesChanged()
+        {
+            (SearchAddressCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (AddResultsToMapCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (GeocodeFileCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+
+        internal void SetSelectedCandidates(IEnumerable<GeocodeCandidate> candidates)
+        {
+            SelectedCandidates.Clear();
+            foreach (var candidate in candidates.Where(c => c != null))
+            {
+                SelectedCandidates.Add(candidate);
+            }
+
+            RaiseResultCommandStatesChanged();
+        }
+
+        private List<GeocodeCandidate> GetSelectedCandidatesForAction()
+        {
+            var selected = SelectedCandidates.Where(HasUsableLocation).ToList();
+            if (selected.Count == 0 && HasUsableLocation(SelectedCandidate))
+            {
+                selected.Add(SelectedCandidate);
+            }
+
+            return selected;
+        }
+
+        private List<GeocodeCandidate> GetCandidatesToWrite()
+        {
+            var selected = SelectedCandidates.ToList();
+            return selected.Count > 0 ? selected : Results.ToList();
         }
 
         /// <summary>
@@ -179,12 +225,23 @@ namespace DuckDBGeoparquet.Views
             }
 
             _isAddingToMap = true;
+            RaiseFileWorkflowCommandStatesChanged();
             try
             {
+                bool usingSelectedCandidates = SelectedCandidates.Count > 0;
+                var candidatesToWrite = GetCandidatesToWrite();
+                if (candidatesToWrite.Count == 0)
+                {
+                    StatusText = "No results to add — run a search first.";
+                    return;
+                }
+
                 StatusText = "Adding results to the map...";
                 string name = $"OvertureGeocode_{DateTime.Now:yyyyMMdd_HHmmss}";
-                await GeocodeResultWriter.WriteToFeatureClassAsync(Results.ToList(), name);
-                StatusText = $"Added {Results.Count} result(s) to the map as '{name}'.";
+                await GeocodeResultWriter.WriteToFeatureClassAsync(candidatesToWrite, name);
+                StatusText = usingSelectedCandidates
+                    ? $"Added {candidatesToWrite.Count} selected result(s) to the map as '{name}'."
+                    : $"Added {candidatesToWrite.Count} result(s) to the map as '{name}'.";
             }
             catch (Exception ex)
             {
@@ -193,6 +250,7 @@ namespace DuckDBGeoparquet.Views
             finally
             {
                 _isAddingToMap = false;
+                RaiseFileWorkflowCommandStatesChanged();
             }
         }
 
@@ -215,6 +273,7 @@ namespace DuckDBGeoparquet.Views
             }
 
             _isGeocodingFile = true;
+            RaiseFileWorkflowCommandStatesChanged();
             try
             {
                 string[] lines = await Task.Run(() => File.ReadAllLines(dialog.FileName));
@@ -299,6 +358,7 @@ namespace DuckDBGeoparquet.Views
             finally
             {
                 _isGeocodingFile = false;
+                RaiseFileWorkflowCommandStatesChanged();
             }
         }
 
@@ -308,10 +368,18 @@ namespace DuckDBGeoparquet.Views
             var cells = new List<string>();
             var sb = new StringBuilder();
             bool inQuotes = false;
-            foreach (char ch in line)
+            for (int i = 0; i < line.Length; i++)
             {
+                char ch = line[i];
                 if (ch == '"')
                 {
+                    if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        continue;
+                    }
+
                     inQuotes = !inQuotes;
                 }
                 else if (ch == ',' && !inQuotes)
@@ -337,16 +405,27 @@ namespace DuckDBGeoparquet.Views
             }
 
             _isSearching = true;
-            (SearchAddressCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            RaiseFileWorkflowCommandStatesChanged();
             StatusText = UseLocatorSearch
-                ? "Searching hybrid candidates (locator mode enabled with local fallback)..."
-                : "Searching hybrid local candidates...";
+                ? "Searching loaded datasets (locator mode enabled with local fallback)..."
+                : "Searching loaded Overture address/place datasets...";
 
             try
             {
-                Envelope extent = await GetCurrentMapExtentWgs84Async();
-                var candidates = await _geocoderService.SearchAsync(SearchQuery, extent, 30);
+                var candidates = await _geocoderService.SearchAsync(SearchQuery, null, 30);
 
+                ClearCandidateOverlays();
+                ClearSelectionOverlays();
+                SelectedCandidates.Clear();
+                _suppressSelectionZoom = true;
+                try
+                {
+                    SelectedCandidate = null;
+                }
+                finally
+                {
+                    _suppressSelectionZoom = false;
+                }
                 Results.Clear();
                 foreach (var candidate in candidates)
                 {
@@ -354,16 +433,17 @@ namespace DuckDBGeoparquet.Views
                 }
 
                 NotifyPropertyChanged(nameof(IsResultListEmpty));
+                RaiseResultCommandStatesChanged();
 
                 if (Results.Count == 0)
                 {
-                    StatusText = "No address/place matches found in loaded ROI data.";
+                    StatusText = "No address/place matches found in the loaded Overture datasets.";
                     SelectedCandidate = null;
                 }
                 else
                 {
-                    SelectedCandidate = Results[0];
-                    StatusText = $"Found {Results.Count} candidate(s).";
+                    await ShowCandidateOverlaysAsync(Results.ToList());
+                    StatusText = $"Found {Results.Count} candidate(s) in the loaded Overture datasets.";
                 }
             }
             catch (Exception ex)
@@ -373,7 +453,7 @@ namespace DuckDBGeoparquet.Views
             finally
             {
                 _isSearching = false;
-                (SearchAddressCommand as RelayCommand)?.RaiseCanExecuteChanged();
+                RaiseFileWorkflowCommandStatesChanged();
             }
         }
 
@@ -433,7 +513,8 @@ namespace DuckDBGeoparquet.Views
 
         private async Task ZoomToSelectedAsync()
         {
-            if (SelectedCandidate == null)
+            var selected = GetSelectedCandidatesForAction();
+            if (selected.Count == 0)
             {
                 return;
             }
@@ -445,26 +526,52 @@ namespace DuckDBGeoparquet.Views
                 return;
             }
 
-            double lon = SelectedCandidate.Longitude;
-            double lat = SelectedCandidate.Latitude;
-            string label = SelectedCandidate.DisplayLabel;
             try
             {
                 // Geometry/symbol construction and overlay/zoom must run on the
                 // MCT (QueuedTask), not the UI thread that raised the selection.
-                var overlay = await QueuedTask.Run(() =>
+                var overlays = await QueuedTask.Run(() =>
                 {
                     var wgs84 = SpatialReferenceBuilder.CreateSpatialReference(4326);
-                    var location = MapPointBuilderEx.CreateMapPoint(lon, lat, wgs84);
                     var marker = SymbolFactory.Instance.ConstructPointSymbol(ColorFactory.Instance.RedRGB, 11.0, SimpleMarkerStyle.Circle);
-                    var handle = mapView.AddOverlay(location, marker.MakeSymbolReference());
-                    mapView.ZoomTo(location);
-                    return handle;
+                    var handles = new List<IDisposable>();
+                    var points = new List<MapPoint>();
+
+                    foreach (var candidate in selected)
+                    {
+                        var location = MapPointBuilderEx.CreateMapPoint(candidate.Longitude, candidate.Latitude, wgs84);
+                        points.Add(location);
+                        handles.Add(mapView.AddOverlay(location, marker.MakeSymbolReference()));
+                    }
+
+                    if (points.Count == 1)
+                    {
+                        mapView.ZoomTo(points[0]);
+                    }
+                    else
+                    {
+                        double xmin = points.Min(p => p.X);
+                        double ymin = points.Min(p => p.Y);
+                        double xmax = points.Max(p => p.X);
+                        double ymax = points.Max(p => p.Y);
+                        if (xmin == xmax && ymin == ymax)
+                        {
+                            mapView.ZoomTo(points[0]);
+                        }
+                        else
+                        {
+                            mapView.ZoomTo(EnvelopeBuilderEx.CreateEnvelope(xmin, ymin, xmax, ymax, wgs84));
+                        }
+                    }
+
+                    return handles;
                 });
 
-                _selectionOverlay?.Dispose();
-                _selectionOverlay = overlay;
-                StatusText = $"Zoomed to {label}";
+                ClearSelectionOverlays();
+                _selectionOverlays.AddRange(overlays);
+                StatusText = selected.Count == 1
+                    ? $"Zoomed to {selected[0].DisplayLabel}"
+                    : $"Zoomed to {selected.Count} selected candidates.";
             }
             catch (Exception ex)
             {
@@ -472,45 +579,95 @@ namespace DuckDBGeoparquet.Views
             }
         }
 
+        private async Task ShowCandidateOverlaysAsync(IReadOnlyList<GeocodeCandidate> candidates)
+        {
+            ClearCandidateOverlays();
+
+            var mapView = MapView.Active;
+            if (mapView == null)
+            {
+                return;
+            }
+
+            var visibleCandidates = candidates
+                .Where(HasUsableLocation)
+                .Take(100)
+                .ToList();
+            if (visibleCandidates.Count == 0)
+            {
+                return;
+            }
+
+            var overlays = await QueuedTask.Run(() =>
+            {
+                var handles = new List<IDisposable>();
+                var wgs84 = SpatialReferenceBuilder.CreateSpatialReference(4326);
+                var marker = SymbolFactory.Instance.ConstructPointSymbol(
+                    new CIMRGBColor { R = 0, G = 122, B = 255, Alpha = 80 },
+                    8.0,
+                    SimpleMarkerStyle.Circle);
+
+                foreach (var candidate in visibleCandidates)
+                {
+                    var location = MapPointBuilderEx.CreateMapPoint(candidate.Longitude, candidate.Latitude, wgs84);
+                    handles.Add(mapView.AddOverlay(location, marker.MakeSymbolReference()));
+                }
+
+                return handles;
+            });
+
+            _candidateOverlays.AddRange(overlays);
+        }
+
+        private static bool HasUsableLocation(GeocodeCandidate candidate)
+        {
+            return candidate != null &&
+                   !double.IsNaN(candidate.Longitude) &&
+                   !double.IsNaN(candidate.Latitude) &&
+                   !double.IsInfinity(candidate.Longitude) &&
+                   !double.IsInfinity(candidate.Latitude) &&
+                   candidate.Longitude >= -180 &&
+                   candidate.Longitude <= 180 &&
+                   candidate.Latitude >= -90 &&
+                   candidate.Latitude <= 90;
+        }
+
+        private void ClearCandidateOverlays()
+        {
+            foreach (var overlay in _candidateOverlays)
+            {
+                try { overlay.Dispose(); }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Candidate overlay cleanup skipped: {ex.Message}"); }
+            }
+            _candidateOverlays.Clear();
+        }
+
+        private void ClearSelectionOverlays()
+        {
+            foreach (var overlay in _selectionOverlays)
+            {
+                try { overlay.Dispose(); }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Selection overlay cleanup skipped: {ex.Message}"); }
+            }
+            _selectionOverlays.Clear();
+        }
+
         private void ClearResults()
         {
             Results.Clear();
+            SelectedCandidates.Clear();
             SelectedCandidate = null;
-            _selectionOverlay?.Dispose();
-            _selectionOverlay = null;
+            ClearCandidateOverlays();
+            ClearSelectionOverlays();
             NotifyPropertyChanged(nameof(IsResultListEmpty));
+            RaiseResultCommandStatesChanged();
             StatusText = "Cleared search results.";
-        }
-
-        private static async Task<Envelope> GetCurrentMapExtentWgs84Async()
-        {
-            Envelope extent = null;
-            await QueuedTask.Run(() =>
-            {
-                var mapView = MapView.Active;
-                if (mapView?.Extent == null)
-                {
-                    return;
-                }
-
-                var mapExtent = mapView.Extent;
-                if (mapExtent.SpatialReference == null || mapExtent.SpatialReference.Wkid != 4326)
-                {
-                    var wgs84 = SpatialReferenceBuilder.CreateSpatialReference(4326);
-                    extent = GeometryEngine.Instance.Project(mapExtent, wgs84) as Envelope;
-                }
-                else
-                {
-                    extent = mapExtent;
-                }
-            });
-
-            return extent;
         }
 
         ~OvertureGeocoderDockpaneViewModel()
         {
-            _selectionOverlay?.Dispose();
+            ClearCandidateOverlays();
+            ClearSelectionOverlays();
             _geocoderService?.Dispose();
         }
     }

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -298,11 +298,20 @@ namespace DuckDBGeoparquet.Views
                 int done = 0;
                 foreach (var q in queries)
                 {
-                    var best = await _geocoderService.GeocodeBestAsync(q);
+                    GeocodeCandidate best = null;
+                    foreach (var searchQuery in q.SearchQueries)
+                    {
+                        best = await _geocoderService.GeocodeBestAsync(searchQuery);
+                        if (HasUsableLocation(best))
+                        {
+                            break;
+                        }
+                    }
+
                     if (HasUsableLocation(best))
                     {
                         matched.Add(best);
-                        matchedQueries.Add(q);
+                        matchedQueries.Add(q.SourceQuery);
                     }
                     done++;
                     if (done % 20 == 0)
@@ -380,11 +389,11 @@ namespace DuckDBGeoparquet.Views
                     "Could not find an address column. Include an 'address' field or separate street fields in the file.");
             }
 
-            var queries = new List<string>();
+            var queries = new List<GeocodeFileQuery>();
             for (int i = firstRow; i < lines.Length && queries.Count < maxRows; i++)
             {
                 var cells = SplitDelimitedLine(lines[i], delimiter);
-                string query = BuildGeocodeQuery(
+                var searchQueries = BuildGeocodeQueries(
                     cells,
                     addressColumn,
                     houseNumberColumn,
@@ -397,21 +406,25 @@ namespace DuckDBGeoparquet.Views
                     stateColumn,
                     zipColumn);
 
-                if (string.IsNullOrWhiteSpace(query) && !looksLikeHeader && cells.Length > 0)
+                if (searchQueries.Count == 0 && !looksLikeHeader && cells.Length > 0)
                 {
-                    query = CleanCell(cells[0]);
+                    string fallback = CleanCell(cells[0]);
+                    if (!string.IsNullOrWhiteSpace(fallback))
+                    {
+                        searchQueries = [fallback];
+                    }
                 }
 
-                if (!string.IsNullOrWhiteSpace(query))
+                if (searchQueries.Count > 0)
                 {
-                    queries.Add(query);
+                    queries.Add(new GeocodeFileQuery(searchQueries[0], searchQueries));
                 }
             }
 
             return new ParsedGeocodeFile(queries, lines.Length - firstRow > maxRows);
         }
 
-        private static string BuildGeocodeQuery(
+        private static IReadOnlyList<string> BuildGeocodeQueries(
             string[] cells,
             int addressColumn,
             int houseNumberColumn,
@@ -442,26 +455,14 @@ namespace DuckDBGeoparquet.Views
 
             if (string.IsNullOrWhiteSpace(address))
             {
-                return string.Empty;
+                return [];
             }
 
             string city = CleanCell(GetCell(cells, cityColumn));
             string state = CleanCell(GetCell(cells, stateColumn));
             string zip = CleanCell(GetCell(cells, zipColumn));
 
-            string locality = string.Join(", ",
-                new[] { city, state }
-                    .Where(part => !string.IsNullOrWhiteSpace(part)));
-            if (!string.IsNullOrWhiteSpace(zip))
-            {
-                locality = string.IsNullOrWhiteSpace(locality)
-                    ? zip
-                    : $"{locality} {zip}";
-            }
-
-            return string.IsNullOrWhiteSpace(locality)
-                ? address
-                : $"{address}, {locality}";
+            return GeocodeFileQueryBuilder.BuildQueryVariants(address, city, state, zip);
         }
 
         private static int FindColumn(string[] normalizedHeader, params string[] aliases)
@@ -614,7 +615,8 @@ namespace DuckDBGeoparquet.Views
             return [.. cells];
         }
 
-        private sealed record ParsedGeocodeFile(IReadOnlyList<string> Queries, bool WasTruncated);
+        private sealed record GeocodeFileQuery(string SourceQuery, IReadOnlyList<string> SearchQueries);
+        private sealed record ParsedGeocodeFile(IReadOnlyList<GeocodeFileQuery> Queries, bool WasTruncated);
 
         private async Task SearchAsync()
         {

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -286,6 +286,7 @@ namespace DuckDBGeoparquet.Views
                 const int MaxRows = 500;
                 var parseResult = ParseGeocodeFileQueries(lines, MaxRows);
                 var queries = parseResult.Queries;
+                System.Diagnostics.Debug.WriteLine($"Geocode file: parsed {queries.Count} query row(s) from '{dialog.FileName}'.");
 
                 if (queries.Count == 0)
                 {
@@ -299,11 +300,16 @@ namespace DuckDBGeoparquet.Views
                 foreach (var q in queries)
                 {
                     GeocodeCandidate best = null;
+                    System.Diagnostics.Debug.WriteLine(
+                        $"Geocode file row {done + 1}: source='{q.SourceQuery}', variants=[{string.Join(" | ", q.SearchQueries)}]");
                     foreach (var searchQuery in q.SearchQueries)
                     {
+                        System.Diagnostics.Debug.WriteLine($"Geocode file row {done + 1}: trying '{searchQuery}'.");
                         best = await _geocoderService.GeocodeBestAsync(searchQuery);
                         if (HasUsableLocation(best))
                         {
+                            System.Diagnostics.Debug.WriteLine(
+                                $"Geocode file row {done + 1}: matched '{best.DisplayLabel}' via '{searchQuery}'.");
                             break;
                         }
                     }
@@ -312,6 +318,10 @@ namespace DuckDBGeoparquet.Views
                     {
                         matched.Add(best);
                         matchedQueries.Add(q.SourceQuery);
+                    }
+                    else
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Geocode file row {done + 1}: no match.");
                     }
                     done++;
                     if (done % 20 == 0)

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -7,9 +7,12 @@ using ArcGIS.Desktop.Mapping;
 using DuckDBGeoparquet.Models;
 using DuckDBGeoparquet.Services;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -26,6 +29,8 @@ namespace DuckDBGeoparquet.Views
         private string _statusText = "Load Addresses + Places first in Overture Maps Data Loader, then search here.";
         private bool _isSearching;
         private bool _isBuildingLocator;
+        private bool _isAddingToMap;
+        private bool _isGeocodingFile;
         private bool _useLocatorSearch;
         private string _locatorStatusText = "Locator not built.";
 
@@ -100,6 +105,11 @@ namespace DuckDBGeoparquet.Views
                 if (SetProperty(ref _selectedCandidate, value))
                 {
                     (ZoomToSelectedCommand as RelayCommand)?.RaiseCanExecuteChanged();
+                    if (value != null)
+                    {
+                        // Like Pro's Locate pane: clicking a result zooms to it.
+                        _ = ZoomToSelectedAsync();
+                    }
                 }
             }
         }
@@ -135,6 +145,8 @@ namespace DuckDBGeoparquet.Views
         public ICommand SearchAddressCommand { get; private set; }
         public ICommand ZoomToSelectedCommand { get; private set; }
         public ICommand ClearResultsCommand { get; private set; }
+        public ICommand AddResultsToMapCommand { get; private set; }
+        public ICommand GeocodeFileCommand { get; private set; }
         public ICommand BuildLocatorCommand { get; private set; }
         public ICommand RebuildLocatorCommand { get; private set; }
         public ICommand RefreshLocatorStatusCommand { get; private set; }
@@ -146,9 +158,174 @@ namespace DuckDBGeoparquet.Views
             SearchAddressCommand = new RelayCommand(async () => await SearchAsync(), () => !_isSearching && !string.IsNullOrWhiteSpace(SearchQuery));
             ZoomToSelectedCommand = new RelayCommand(async () => await ZoomToSelectedAsync(), () => SelectedCandidate != null);
             ClearResultsCommand = new RelayCommand(ClearResults);
+            AddResultsToMapCommand = new RelayCommand(async () => await AddResultsToMapAsync(), () => !_isAddingToMap);
+            GeocodeFileCommand = new RelayCommand(async () => await GeocodeFileAsync(), () => !_isGeocodingFile);
             BuildLocatorCommand = new RelayCommand(async () => await BuildLocatorAsync(false), () => !_isBuildingLocator);
             RebuildLocatorCommand = new RelayCommand(async () => await BuildLocatorAsync(true), () => !_isBuildingLocator);
             RefreshLocatorStatusCommand = new RelayCommand(RefreshLocatorStatus);
+        }
+
+        /// <summary>
+        /// Writes the current search results to a point feature class in the
+        /// project geodatabase and adds it to the map (Locate pane's
+        /// "Add To Feature Class" behavior).
+        /// </summary>
+        private async Task AddResultsToMapAsync()
+        {
+            if (Results.Count == 0)
+            {
+                StatusText = "No results to add — run a search first.";
+                return;
+            }
+
+            _isAddingToMap = true;
+            try
+            {
+                StatusText = "Adding results to the map...";
+                string name = $"OvertureGeocode_{DateTime.Now:yyyyMMdd_HHmmss}";
+                await GeocodeResultWriter.WriteToFeatureClassAsync(Results.ToList(), name);
+                StatusText = $"Added {Results.Count} result(s) to the map as '{name}'.";
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"Could not add results to the map: {ex.Message}";
+            }
+            finally
+            {
+                _isAddingToMap = false;
+            }
+        }
+
+        /// <summary>
+        /// Geocodes a delimited file of addresses (like the Geocode File tool)
+        /// using the same search pipeline as single queries — the ArcGIS
+        /// locator when preferred and ready, the local DuckDB search otherwise
+        /// — and adds the matches to the map as a feature class.
+        /// </summary>
+        private async Task GeocodeFileAsync()
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "Select a file of addresses to geocode",
+                Filter = "Delimited text (*.csv;*.txt)|*.csv;*.txt|All files (*.*)|*.*"
+            };
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            _isGeocodingFile = true;
+            try
+            {
+                string[] lines = await Task.Run(() => File.ReadAllLines(dialog.FileName));
+                if (lines.Length == 0)
+                {
+                    StatusText = "The selected file is empty.";
+                    return;
+                }
+
+                // Use a column named address/single line when the header has
+                // one; otherwise treat every row's first column as the query.
+                string[] header = SplitCsvLine(lines[0]);
+                string[] knownNames = ["address", "singleline", "single_line", "single line input", "full_address", "street"];
+                int column = -1;
+                for (int i = 0; i < header.Length; i++)
+                {
+                    if (knownNames.Contains(header[i].Trim().Trim('"').ToLowerInvariant()))
+                    {
+                        column = i;
+                        break;
+                    }
+                }
+                int firstRow = column >= 0 ? 1 : 0;
+                if (column < 0) column = 0;
+
+                const int MaxRows = 500;
+                var queries = new List<string>();
+                for (int i = firstRow; i < lines.Length && queries.Count < MaxRows; i++)
+                {
+                    var cells = SplitCsvLine(lines[i]);
+                    if (cells.Length > column)
+                    {
+                        string q = cells[column].Trim().Trim('"');
+                        if (!string.IsNullOrWhiteSpace(q))
+                        {
+                            queries.Add(q);
+                        }
+                    }
+                }
+
+                if (queries.Count == 0)
+                {
+                    StatusText = "No addresses found in the file.";
+                    return;
+                }
+
+                var matched = new List<GeocodeCandidate>();
+                var matchedQueries = new List<string>();
+                int done = 0;
+                foreach (var q in queries)
+                {
+                    var best = await _geocoderService.GeocodeBestAsync(q);
+                    if (best != null)
+                    {
+                        matched.Add(best);
+                        matchedQueries.Add(q);
+                    }
+                    done++;
+                    if (done % 20 == 0)
+                    {
+                        StatusText = $"Geocoding file... {done}/{queries.Count}";
+                    }
+                }
+
+                if (matched.Count == 0)
+                {
+                    StatusText = $"No matches for {queries.Count} address(es).";
+                    return;
+                }
+
+                string name = $"OvertureGeocodeFile_{DateTime.Now:yyyyMMdd_HHmmss}";
+                await GeocodeResultWriter.WriteToFeatureClassAsync(matched, name, matchedQueries);
+                bool truncated = lines.Length - firstRow > MaxRows;
+                StatusText = $"Geocoded {matched.Count} of {queries.Count} address(es)" +
+                             (truncated ? $" (first {MaxRows} rows)" : string.Empty) +
+                             $"; added layer '{name}'.";
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"Geocode file failed: {ex.Message}";
+            }
+            finally
+            {
+                _isGeocodingFile = false;
+            }
+        }
+
+        private static string[] SplitCsvLine(string line)
+        {
+            // Minimal CSV split honoring double-quoted cells.
+            var cells = new List<string>();
+            var sb = new StringBuilder();
+            bool inQuotes = false;
+            foreach (char ch in line)
+            {
+                if (ch == '"')
+                {
+                    inQuotes = !inQuotes;
+                }
+                else if (ch == ',' && !inQuotes)
+                {
+                    cells.Add(sb.ToString());
+                    sb.Clear();
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+            }
+            cells.Add(sb.ToString());
+            return [.. cells];
         }
 
         private async Task SearchAsync()

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -265,7 +265,7 @@ namespace DuckDBGeoparquet.Views
             var dialog = new Microsoft.Win32.OpenFileDialog
             {
                 Title = "Select a file of addresses to geocode",
-                Filter = "Delimited text (*.csv;*.txt)|*.csv;*.txt|All files (*.*)|*.*"
+                Filter = "Delimited text (*.csv;*.txt;*.tsv)|*.csv;*.txt;*.tsv|All files (*.*)|*.*"
             };
             if (dialog.ShowDialog() != true)
             {
@@ -283,36 +283,9 @@ namespace DuckDBGeoparquet.Views
                     return;
                 }
 
-                // Use a column named address/single line when the header has
-                // one; otherwise treat every row's first column as the query.
-                string[] header = SplitCsvLine(lines[0]);
-                string[] knownNames = ["address", "singleline", "single_line", "single line input", "full_address", "street"];
-                int column = -1;
-                for (int i = 0; i < header.Length; i++)
-                {
-                    if (knownNames.Contains(header[i].Trim().Trim('"').ToLowerInvariant()))
-                    {
-                        column = i;
-                        break;
-                    }
-                }
-                int firstRow = column >= 0 ? 1 : 0;
-                if (column < 0) column = 0;
-
                 const int MaxRows = 500;
-                var queries = new List<string>();
-                for (int i = firstRow; i < lines.Length && queries.Count < MaxRows; i++)
-                {
-                    var cells = SplitCsvLine(lines[i]);
-                    if (cells.Length > column)
-                    {
-                        string q = cells[column].Trim().Trim('"');
-                        if (!string.IsNullOrWhiteSpace(q))
-                        {
-                            queries.Add(q);
-                        }
-                    }
-                }
+                var parseResult = ParseGeocodeFileQueries(lines, MaxRows);
+                var queries = parseResult.Queries;
 
                 if (queries.Count == 0)
                 {
@@ -326,7 +299,7 @@ namespace DuckDBGeoparquet.Views
                 foreach (var q in queries)
                 {
                     var best = await _geocoderService.GeocodeBestAsync(q);
-                    if (best != null)
+                    if (HasUsableLocation(best))
                     {
                         matched.Add(best);
                         matchedQueries.Add(q);
@@ -346,9 +319,8 @@ namespace DuckDBGeoparquet.Views
 
                 string name = $"OvertureGeocodeFile_{DateTime.Now:yyyyMMdd_HHmmss}";
                 await GeocodeResultWriter.WriteToFeatureClassAsync(matched, name, matchedQueries);
-                bool truncated = lines.Length - firstRow > MaxRows;
                 StatusText = $"Geocoded {matched.Count} of {queries.Count} address(es)" +
-                             (truncated ? $" (first {MaxRows} rows)" : string.Empty) +
+                             (parseResult.WasTruncated ? $" (first {MaxRows} rows)" : string.Empty) +
                              $"; added layer '{name}'.";
             }
             catch (Exception ex)
@@ -362,9 +334,255 @@ namespace DuckDBGeoparquet.Views
             }
         }
 
-        private static string[] SplitCsvLine(string line)
+        private static ParsedGeocodeFile ParseGeocodeFileQueries(string[] lines, int maxRows)
         {
-            // Minimal CSV split honoring double-quoted cells.
+            char delimiter = DetectDelimiter(lines[0]);
+            string[] header = SplitDelimitedLine(lines[0], delimiter);
+            string[] normalizedHeader = [.. header.Select(NormalizeHeaderToken)];
+
+            bool looksLikeHeader = normalizedHeader.Any(IsKnownGeocodeHeaderName);
+            int firstRow = looksLikeHeader ? 1 : 0;
+
+            int addressColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "address", "singleline", "single_line", "single line input", "full_address")
+                : (header.Length == 1 ? 0 : -1);
+            int streetColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "street", "street_name", "road", "name", "saddstr")
+                : -1;
+            int houseNumberColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "number", "housenumber", "house_number", "saddno")
+                : -1;
+            int housePrefixColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "prefix", "predir", "streetprefix", "saddpref")
+                : -1;
+            int streetTypeColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "streettype", "street_type", "sttype", "saddsttyp")
+                : -1;
+            int streetSuffixColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "suffix", "postdir", "streetsuffix", "saddstsuf")
+                : -1;
+            int unitColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "unit", "apt", "apartment", "suite", "sunit")
+                : -1;
+            int cityColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "city", "scity", "locality")
+                : -1;
+            int stateColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "state", "state2", "region", "province")
+                : -1;
+            int zipColumn = looksLikeHeader
+                ? FindColumn(normalizedHeader, "zip", "zip5", "szip", "szip5", "postcode", "postalcode")
+                : -1;
+
+            if (looksLikeHeader && addressColumn < 0 && streetColumn < 0)
+            {
+                throw new InvalidOperationException(
+                    "Could not find an address column. Include an 'address' field or separate street fields in the file.");
+            }
+
+            var queries = new List<string>();
+            for (int i = firstRow; i < lines.Length && queries.Count < maxRows; i++)
+            {
+                var cells = SplitDelimitedLine(lines[i], delimiter);
+                string query = BuildGeocodeQuery(
+                    cells,
+                    addressColumn,
+                    houseNumberColumn,
+                    housePrefixColumn,
+                    streetColumn,
+                    streetTypeColumn,
+                    streetSuffixColumn,
+                    unitColumn,
+                    cityColumn,
+                    stateColumn,
+                    zipColumn);
+
+                if (string.IsNullOrWhiteSpace(query) && !looksLikeHeader && cells.Length > 0)
+                {
+                    query = CleanCell(cells[0]);
+                }
+
+                if (!string.IsNullOrWhiteSpace(query))
+                {
+                    queries.Add(query);
+                }
+            }
+
+            return new ParsedGeocodeFile(queries, lines.Length - firstRow > maxRows);
+        }
+
+        private static string BuildGeocodeQuery(
+            string[] cells,
+            int addressColumn,
+            int houseNumberColumn,
+            int housePrefixColumn,
+            int streetColumn,
+            int streetTypeColumn,
+            int streetSuffixColumn,
+            int unitColumn,
+            int cityColumn,
+            int stateColumn,
+            int zipColumn)
+        {
+            string address = CleanCell(GetCell(cells, addressColumn));
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                var addressParts = new[]
+                {
+                    CleanCell(GetCell(cells, houseNumberColumn)),
+                    CleanCell(GetCell(cells, housePrefixColumn)),
+                    CleanCell(GetCell(cells, streetColumn)),
+                    CleanCell(GetCell(cells, streetTypeColumn)),
+                    CleanCell(GetCell(cells, streetSuffixColumn)),
+                    CleanCell(GetCell(cells, unitColumn))
+                };
+
+                address = string.Join(" ", addressParts.Where(part => !string.IsNullOrWhiteSpace(part)));
+            }
+
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                return string.Empty;
+            }
+
+            string city = CleanCell(GetCell(cells, cityColumn));
+            string state = CleanCell(GetCell(cells, stateColumn));
+            string zip = CleanCell(GetCell(cells, zipColumn));
+
+            string locality = string.Join(", ",
+                new[] { city, state }
+                    .Where(part => !string.IsNullOrWhiteSpace(part)));
+            if (!string.IsNullOrWhiteSpace(zip))
+            {
+                locality = string.IsNullOrWhiteSpace(locality)
+                    ? zip
+                    : $"{locality} {zip}";
+            }
+
+            return string.IsNullOrWhiteSpace(locality)
+                ? address
+                : $"{address}, {locality}";
+        }
+
+        private static int FindColumn(string[] normalizedHeader, params string[] aliases)
+        {
+            var normalizedAliases = aliases
+                .Select(NormalizeHeaderToken)
+                .Where(alias => !string.IsNullOrWhiteSpace(alias))
+                .ToHashSet(StringComparer.Ordinal);
+
+            for (int i = 0; i < normalizedHeader.Length; i++)
+            {
+                if (normalizedAliases.Contains(normalizedHeader[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static bool IsKnownGeocodeHeaderName(string name)
+        {
+            return FindColumn(
+                [name],
+                "address",
+                "singleline",
+                "single_line",
+                "single line input",
+                "full_address",
+                "street",
+                "street_name",
+                "road",
+                "name",
+                "saddstr",
+                "saddno",
+                "city",
+                "scity",
+                "state",
+                "state2",
+                "zip",
+                "szip",
+                "postcode") >= 0;
+        }
+
+        private static string NormalizeHeaderToken(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var normalized = new StringBuilder(value.Length);
+            foreach (char ch in value.Trim().Trim('"').ToLowerInvariant())
+            {
+                if (char.IsLetterOrDigit(ch))
+                {
+                    normalized.Append(ch);
+                }
+            }
+
+            return normalized.ToString();
+        }
+
+        private static string GetCell(string[] cells, int index)
+        {
+            return index >= 0 && index < cells.Length ? cells[index] : string.Empty;
+        }
+
+        private static string CleanCell(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            return string.Join(" ",
+                value.Trim().Trim('"')
+                    .Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        private static char DetectDelimiter(string line)
+        {
+            char bestDelimiter = ',';
+            int bestCount = -1;
+
+            foreach (char candidate in new[] { '\t', ',', ';', '|' })
+            {
+                int count = 0;
+                bool inQuotes = false;
+                for (int i = 0; i < line.Length; i++)
+                {
+                    char ch = line[i];
+                    if (ch == '"')
+                    {
+                        if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                        {
+                            i++;
+                            continue;
+                        }
+
+                        inQuotes = !inQuotes;
+                    }
+                    else if (ch == candidate && !inQuotes)
+                    {
+                        count++;
+                    }
+                }
+
+                if (count > bestCount)
+                {
+                    bestDelimiter = candidate;
+                    bestCount = count;
+                }
+            }
+
+            return bestDelimiter;
+        }
+
+        private static string[] SplitDelimitedLine(string line, char delimiter)
+        {
+            // Minimal delimited split honoring double-quoted cells.
             var cells = new List<string>();
             var sb = new StringBuilder();
             bool inQuotes = false;
@@ -382,7 +600,7 @@ namespace DuckDBGeoparquet.Views
 
                     inQuotes = !inQuotes;
                 }
-                else if (ch == ',' && !inQuotes)
+                else if (ch == delimiter && !inQuotes)
                 {
                     cells.Add(sb.ToString());
                     sb.Clear();
@@ -395,6 +613,8 @@ namespace DuckDBGeoparquet.Views
             cells.Add(sb.ToString());
             return [.. cells];
         }
+
+        private sealed record ParsedGeocodeFile(IReadOnlyList<string> Queries, bool WasTruncated);
 
         private async Task SearchAsync()
         {

--- a/Views/OvertureGeocoderShowButton.cs
+++ b/Views/OvertureGeocoderShowButton.cs
@@ -15,8 +15,8 @@ namespace DuckDBGeoparquet.Views
             {
                 System.Diagnostics.Debug.WriteLine($"Error opening Overture geocoder: {ex.Message}");
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(
-                    "Unable to open Overture ROI Geocoder. See ArcGIS Pro logs for details.",
-                    "Overture ROI Geocoder",
+                    "Unable to open Overture Geocoder. See ArcGIS Pro logs for details.",
+                    "Overture Geocoder",
                     System.Windows.MessageBoxButton.OK,
                     System.Windows.MessageBoxImage.Error);
             }

--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -86,9 +86,14 @@ drives the extent.
 - `DuckDBManager` (connection lifecycle + extension loading) — DONE.
   `DataProcessor` proxies `_connection`/`_isInitialized` so call sites are
   unchanged; behavior and error messages are moved verbatim.
-- Remaining: `S3Ingester`, `ParquetExporter`, `LayerManager`,
-  `GeocoderEngine`. Extract the pure parts (column projection, query text
-  builders) into testable classes as they move.
+- `GeocoderEngine` (address/place candidate search) — DONE. Query logic
+  moved verbatim; `DataProcessor` keeps thin delegating wrappers for its
+  public search API. `EscapeSqlLiteral` promoted to `GeoParquetSql` with
+  test coverage.
+- Remaining: `S3Ingester`, `ParquetExporter`, `LayerManager`. These share
+  mutable per-load state (`_pendingLayers`, `_currentExtent`, session
+  suffix), so extract them together or thread the state through a small
+  load-context object.
 - Stage 3: extract `DataLoadOrchestrator` and `MfcOrchestrator` from
   `WizardDockpaneViewModel.cs` (load pipeline, bulk replacement, P/Invoke
   deletion, extent resolution; MFC creation).

--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -59,10 +59,10 @@ drives the extent.
 **Verification checklist (requires ArcGIS Pro 3.7 on Windows):**
 1. `dotnet build` — confirm removing `Esri.ArcGISRuntime` broke nothing.
 2. Open Preview tab → map loads, "Preview map ready." appears in the log.
-3. Show Extent draws the configured extent; Use Preview Extent round-trips
-   (pan/zoom, adopt, confirm the WGS84 coords in Select Data).
-4. Export a small area with **SNAPPY**, Preview Data → layers render.
-   Repeat with ZSTD → per-layer error + the compression warning in the log.
+3. Show Extent draws the configured extent from the active Pro map or custom
+   extent.
+4. Select one or more themes, click Preview Sample, and confirm capped
+   GeoJSON sample layers render from S3.
 5. Disconnect from the network, reload the pane → offline notice, no crash.
 6. If Pro's bundled WebView2 assemblies conflict with the NuGet version,
    pin `Microsoft.Web.WebView2` to the version Pro ships.


### PR DESCRIPTION
## Summary

Started as Phase 2c stage 2 (`GeocoderEngine` extraction) and grew, through on-machine testing, into getting the ROI Geocoder fully working end-to-end.

### Refactor (Phase 2c stage 2)
- **`GeocoderEngine`** extracted from `DataProcessor` (address/place candidate search), backed by the shared `DuckDBManager`; `DataProcessor` keeps delegating wrappers so `OvertureGeocoderService` is unchanged.
- `EscapeSqlLiteral` promoted to the tested `GeoParquetSql` class.

### Locator build — now works end-to-end (fixed iteratively against a real County machine)
- **Fail fast on a locked scratch geodatabase** with an actionable message (was a swallowed debug line → doomed build).
- **Stage the newest parquet** per theme (folders accumulate session-stamped files because load cleanups skip locked ones).
- **`GPExecuteToolFlags.None`** so staged scratch feature classes don't get added to the map or lock the scratch GDB.
- **Build failures stay visible** in the pane (were overwritten by the status refresh).
- **`CreateFeatureLocator` search-fields grammar**: `*Name <field> VISIBLE NONE` (ERROR 003057).
- **Place/address field fallbacks** cover flattened Overture struct names (`names_primary` etc.) and list the actual fields on failure.
- **Composite locator paths quoted** so spaces (`OneDrive - County of Fresno`) don't break the value table (ERROR 003343/000735); if the composite still fails, **degrade to registering the address + place locators individually**.
- **Register built locator(s) with the project** (`ItemFactory` + `Project.AddItem`) so they become providers.

### Locator is actually used for search
- Wired the previously-dead **"Prefer ArcGIS Locator"** checkbox through `MapView.Active.LocatorManager.GeocodeAsync`, results projected to WGS84 and ROI-filtered, falling back to the DuckDB search when the locator returns nothing.

### Locate-pane-style workflow
- **Click a result → map zooms** to it (no button press).
- **Add Results to Map**: current candidates → point feature class in the project GDB (`XY Table To Point`) → added as a layer.
- **Geocode File…**: pick a CSV of addresses, geocode each row through the same pipeline (locator-or-DuckDB), add matches to the map with the original query preserved (500-row cap, progress readout).
- **Fix JSON-ish place labels**: use `names.primary` / `categories.primary` instead of casting the whole Overture struct.

## Testing
- CI green (build + 19 unit tests).
- On a County-managed machine (Pro 3.7, VS 2026): bundled DuckDB extensions load under Application Control policy; DuckDB search returns correct address hits; the hybrid locator builds, registers, and appears in Pro's own Locate pane. **Still to confirm by the user:** click-to-zoom, Add Results to Map, Geocode File.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1fTVZhA1frgU7EpZeuQnJ