### PR TITLE
Phase 2c stage 2 — extract S3Ingester query builders from DataProcessor

### DIFF
--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -9,7 +9,9 @@
 		     SDK assemblies, which only resolve usefully on a machine with Pro
 		     installed. Anything linked here must stay free of ArcGIS types. -->
 		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
+		<Compile Include="..\Models\OvertureSchema.cs" Link="Linked\OvertureSchema.cs" />
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
+		<Compile Include="..\Services\S3Ingester.cs" Link="Linked\S3Ingester.cs" />
 		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/DuckDBGeoparquet.Tests/S3IngesterTests.cs
+++ b/DuckDBGeoparquet.Tests/S3IngesterTests.cs
@@ -1,0 +1,119 @@
+using DuckDBGeoparquet.Models;
+using DuckDBGeoparquet.Services;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class S3IngesterTests
+    {
+        [Fact]
+        public void BuildColumnProjection_RetainsAllColumns_WhenTypeHasExclusionsButNonePresent()
+        {
+            // "building" only drops "sources"; a file without it keeps every
+            // column, yielding an explicit full projection (not null).
+            var columns = new List<string> { "id", "geometry", "bbox" };
+            Assert.Equal("id, geometry, bbox", S3Ingester.BuildColumnProjection("building", columns));
+        }
+
+        [Fact]
+        public void BuildColumnProjection_ReturnsNull_ForUnknownType()
+        {
+            var columns = new List<string> { "id", "geometry" };
+            Assert.Null(S3Ingester.BuildColumnProjection("not_a_real_theme", columns));
+        }
+
+        [Fact]
+        public void BuildColumnProjection_ReturnsNull_ForNullOrEmptyInputs()
+        {
+            Assert.Null(S3Ingester.BuildColumnProjection(null, new List<string> { "id" }));
+            Assert.Null(S3Ingester.BuildColumnProjection("place", null));
+            Assert.Null(S3Ingester.BuildColumnProjection("place", new List<string>()));
+        }
+
+        [Fact]
+        public void BuildColumnProjection_DropsExcludedColumns()
+        {
+            // "place" excludes addresses, brand, emails, phones, socials, sources, websites.
+            var columns = new List<string> { "id", "geometry", "bbox", "names", "sources", "websites", "brand" };
+            string projection = S3Ingester.BuildColumnProjection("place", columns);
+
+            Assert.NotNull(projection);
+            Assert.Contains("id", projection);
+            Assert.Contains("names", projection);
+            Assert.DoesNotContain("sources", projection);
+            Assert.DoesNotContain("websites", projection);
+            Assert.DoesNotContain("brand", projection);
+        }
+
+        [Fact]
+        public void BuildColumnProjection_NeverDropsGeometryOrBboxSubColumns()
+        {
+            // Even if a geometry/bbox_* column somehow collided with an exclusion
+            // name, the projection must always retain it.
+            var columns = new List<string> { "geometry", "bbox_xmin", "bbox_ymax", "sources" };
+            string projection = S3Ingester.BuildColumnProjection("place", columns);
+
+            Assert.NotNull(projection);
+            Assert.Contains("geometry", projection);
+            Assert.Contains("bbox_xmin", projection);
+            Assert.Contains("bbox_ymax", projection);
+            Assert.DoesNotContain("sources", projection);
+        }
+
+        [Fact]
+        public void BuildLoadQuery_NoExtent_SelectsStarWhenNoProjection()
+        {
+            // A null/unknown type yields no projection → SELECT *.
+            var columns = new List<string> { "id", "geometry", "bbox" };
+            string query = S3Ingester.BuildLoadQuery("s3://bucket/*.parquet", actualS3Type: null, columns, extent: null);
+
+            Assert.Contains("CREATE OR REPLACE TABLE current_table", query);
+            Assert.Contains("SELECT *", query);
+            Assert.Contains("read_parquet('s3://bucket/*.parquet', filename=true, hive_partitioning=1)", query);
+            // No extent → no spatial filter and no clipping.
+            Assert.DoesNotContain("WHERE", query);
+            Assert.DoesNotContain("ST_Intersection", query);
+        }
+
+        [Fact]
+        public void BuildLoadQuery_NoExtent_UsesProjectionWhenExclusionsApply()
+        {
+            var columns = new List<string> { "id", "geometry", "bbox", "sources" };
+            string query = S3Ingester.BuildLoadQuery("s3://bucket/place/*", "place", columns, extent: null);
+
+            Assert.Contains("SELECT id, geometry, bbox", query);
+            Assert.DoesNotContain("sources", query);
+        }
+
+        [Fact]
+        public void BuildLoadQuery_WithExtentAndBbox_ClipsAndRepacksBbox()
+        {
+            var extent = new ExtentBounds(1, 2, 3, 4);
+            var columns = new List<string> { "id", "geometry", "bbox" };
+            string query = S3Ingester.BuildLoadQuery("s3://bucket/place/*", "place", columns, extent);
+
+            // bbox present → repack via struct_pack after clipping.
+            Assert.Contains("WITH clipped AS", query);
+            Assert.Contains("ST_Intersection(geometry,", query);
+            Assert.Contains("struct_pack", query);
+            Assert.Contains("AS bbox", query);
+            // Pushdown predicate + refinement filter are both present.
+            Assert.Contains("bbox.xmin <= 3", query);
+            Assert.Contains("ST_Intersects(geometry,", query);
+        }
+
+        [Fact]
+        public void BuildLoadQuery_WithExtentNoBbox_ClipsGeometryWithoutRepack()
+        {
+            var extent = new ExtentBounds(1, 2, 3, 4);
+            var columns = new List<string> { "id", "geometry" };
+            string query = S3Ingester.BuildLoadQuery("s3://bucket/data/*", actualS3Type: null, columns, extent);
+
+            Assert.Contains("ST_Intersection(geometry,", query);
+            Assert.Contains("* EXCLUDE(geometry)", query);
+            // No bbox column → no struct_pack repack.
+            Assert.DoesNotContain("struct_pack", query);
+        }
+    }
+}

--- a/Services/DataProcessor.cs
+++ b/Services/DataProcessor.cs
@@ -41,8 +41,6 @@ namespace DuckDBGeoparquet.Services
         // Constants
         private const string DEFAULT_SRS = "EPSG:4326";
         private const string STRUCT_TYPE = "STRUCT";
-        private const string BBOX_COLUMN = "bbox";
-        private const string GEOMETRY_COLUMN = "geometry";
 
         // Add static readonly field for the theme-type separator
         private static readonly string[] THEME_TYPE_SEPARATOR = [" - "];
@@ -243,23 +241,10 @@ namespace DuckDBGeoparquet.Services
                 }
                 System.Diagnostics.Debug.WriteLine($"Schema validated: {columnNames.Count} columns found");
 
-                // Build a selective column list to trim heavy structs/arrays when safe
-                var projectedColumns = BuildColumnProjection(actualS3Type, columnNames);
-
                 progress?.Report($"Loading data from S3 (this may take a moment)...");
 
-                string spatialFilter = "";
-                string extentPolygon = "";
                 if (extent != null)
                 {
-                    // Create a polygon from the extent for clipping
-                    extentPolygon = GeoParquetSql.BuildExtentPolygon(extent);
-
-                    // Bbox overlap first (pushdown), then ST_Intersects so only features whose geometry
-                    // actually intersects the extent are kept — prevents data extending beyond the frame.
-                    spatialFilter = $@"
-                        WHERE {GeoParquetSql.BuildBboxOverlapPredicate(extent)}
-                          AND ST_Intersects(geometry, {extentPolygon})";
                     System.Diagnostics.Debug.WriteLine($"[{actualS3Type}] Spatial filter: requested extent=({GeoParquetSql.FormatCoordinate(extent.XMin)}, {GeoParquetSql.FormatCoordinate(extent.YMin)}) to ({GeoParquetSql.FormatCoordinate(extent.XMax)}, {GeoParquetSql.FormatCoordinate(extent.YMax)}), bbox overlap + ST_Intersects");
                     progress?.Report($"Applying spatial filter for current map extent...");
                 }
@@ -268,81 +253,11 @@ namespace DuckDBGeoparquet.Services
                     System.Diagnostics.Debug.WriteLine("WARNING: No extent provided - loading all data without spatial filter!");
                 }
 
-                // Build query with optional geometry clipping
-                string query;
-                // Determine which columns to project (if any) while always retaining geometry
-                var projectedColumnList = projectedColumns ?? "*";
-                bool hasBboxColumn = columnNames.Any(c => c.Equals(BBOX_COLUMN, StringComparison.OrdinalIgnoreCase));
-                var projectedColumnsWithoutGeometry = projectedColumns != null
-                    ? string.Join(", ", projectedColumns.Split(',').Select(c => c.Trim()).Where(c => !c.Equals("geometry", StringComparison.OrdinalIgnoreCase)))
-                    : "* EXCLUDE(geometry)";
-                var projectedColumnsWithoutGeometryOrBbox = projectedColumns != null
-                    ? string.Join(", ", projectedColumns.Split(',').Select(c => c.Trim()).Where(c =>
-                        !c.Equals("geometry", StringComparison.OrdinalIgnoreCase) &&
-                        !c.Equals(BBOX_COLUMN, StringComparison.OrdinalIgnoreCase)))
-                    : (hasBboxColumn ? "* EXCLUDE(geometry, bbox)" : "* EXCLUDE(geometry)");
-                if (string.IsNullOrWhiteSpace(projectedColumnsWithoutGeometry))
-                    projectedColumnsWithoutGeometry = "* EXCLUDE(geometry)";
-                if (string.IsNullOrWhiteSpace(projectedColumnsWithoutGeometryOrBbox))
-                    projectedColumnsWithoutGeometryOrBbox = hasBboxColumn ? "* EXCLUDE(geometry, bbox)" : "* EXCLUDE(geometry)";
+                // Build query with optional column projection and geometry clipping.
+                // The pure builder trims heavy structs/arrays when safe and applies
+                // the bbox pushdown + ST_Intersects filter and clipping (see S3Ingester).
+                string query = S3Ingester.BuildLoadQuery(s3Path, actualS3Type, columnNames, extent);
 
-                if (extent != null && !string.IsNullOrEmpty(extentPolygon))
-                {
-                    // Clip geometries to extent - this keeps all intersecting features but clips them to the extent
-                    // Use ST_Intersection to clip, and only include features that actually intersect
-                    if (hasBboxColumn)
-                    {
-                        query = $@"
-                        CREATE OR REPLACE TABLE current_table AS 
-                        WITH clipped AS (
-                            SELECT
-                                {projectedColumnsWithoutGeometryOrBbox},
-                                CASE
-                                    WHEN ST_Intersects(geometry, {extentPolygon})
-                                    THEN ST_Intersection(geometry, {extentPolygon})
-                                    ELSE NULL
-                                END AS clipped_geometry
-                            FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
-                            {spatialFilter}
-                        )
-                        SELECT
-                            * EXCLUDE(clipped_geometry),
-                            clipped_geometry AS geometry,
-                            CASE
-                                WHEN clipped_geometry IS NOT NULL THEN struct_pack(
-                                    xmin := ST_XMin(clipped_geometry),
-                                    ymin := ST_YMin(clipped_geometry),
-                                    xmax := ST_XMax(clipped_geometry),
-                                    ymax := ST_YMax(clipped_geometry)
-                                )
-                                ELSE NULL
-                            END AS bbox
-                        FROM clipped";
-                    }
-                    else
-                    {
-                        query = $@"
-                        CREATE OR REPLACE TABLE current_table AS 
-                        SELECT 
-                            {projectedColumnsWithoutGeometry},
-                            CASE 
-                                WHEN ST_Intersects(geometry, {extentPolygon}) 
-                                THEN ST_Intersection(geometry, {extentPolygon})
-                                ELSE NULL
-                            END as geometry
-                        FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
-                        {spatialFilter}";
-                    }
-                }
-                else
-                {
-                    query = $@"
-                        CREATE OR REPLACE TABLE current_table AS 
-                        SELECT {projectedColumnList}
-                        FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
-                        {spatialFilter}";
-                }
-                
                 // Clear command text before setting new query to ensure clean state
                 command.CommandText = string.Empty;
                 command.CommandText = query;
@@ -405,33 +320,6 @@ namespace DuckDBGeoparquet.Services
             if (midLon >= 165 && midLon <= 180 && midLat >= -48 && midLat <= -34) return "NZ";
             if (midLon >= -180 && midLon <= -165 && midLat >= -48 && midLat <= -34) return "NZ";
             return null;
-        }
-
-        /// <summary>
-        /// Build a projection list that drops known heavy optional columns for the given dataset type.
-        /// Returns null to indicate "SELECT *" when no drops apply.
-        /// </summary>
-        private static string BuildColumnProjection(string actualS3Type, List<string> columnNames)
-        {
-            if (string.IsNullOrWhiteSpace(actualS3Type) || columnNames == null || columnNames.Count == 0)
-                return null;
-
-            if (!OvertureSchema.ColumnExclusions.TryGetValue(actualS3Type, out var dropSet) || dropSet.Count == 0)
-                return null;
-
-            var projected = columnNames
-                .Where(name =>
-                    // Never drop geometry or bbox even if listed
-                    name.Equals(GEOMETRY_COLUMN, StringComparison.OrdinalIgnoreCase) ||
-                    name.StartsWith($"{BBOX_COLUMN}_", StringComparison.OrdinalIgnoreCase) ||
-                    !dropSet.Contains(name))
-                .ToList();
-
-            // If projection would drop everything (unlikely), fall back to *
-            if (!projected.Any())
-                return null;
-
-            return string.Join(", ", projected);
         }
 
         public async Task<DataTable> GetPreviewDataAsync(CancellationToken cancellationToken = default)

--- a/Services/S3Ingester.cs
+++ b/Services/S3Ingester.cs
@@ -1,0 +1,144 @@
+using DuckDBGeoparquet.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Pure query-text builders for the S3 → DuckDB ingest step. Given a set of
+    /// discovered column names and the requested extent, these produce the
+    /// column projection and the CREATE OR REPLACE TABLE current_table query
+    /// that <see cref="DataProcessor.IngestFileAsync"/> executes.
+    ///
+    /// No ArcGIS or DuckDB dependencies — everything here is deterministic
+    /// string construction, which makes it unit-testable without ArcGIS Pro
+    /// running (see DuckDBGeoparquet.Tests). Extracted from DataProcessor
+    /// (Phase 2c stage 2).
+    /// </summary>
+    public static class S3Ingester
+    {
+        private const string BboxColumn = "bbox";
+        private const string GeometryColumn = "geometry";
+
+        /// <summary>
+        /// Build a projection list that drops known heavy optional columns for the given dataset type.
+        /// Returns null to indicate "SELECT *" when no drops apply.
+        /// </summary>
+        public static string BuildColumnProjection(string actualS3Type, IReadOnlyList<string> columnNames)
+        {
+            if (string.IsNullOrWhiteSpace(actualS3Type) || columnNames == null || columnNames.Count == 0)
+                return null;
+
+            if (!OvertureSchema.ColumnExclusions.TryGetValue(actualS3Type, out var dropSet) || dropSet.Count == 0)
+                return null;
+
+            var projected = columnNames
+                .Where(name =>
+                    // Never drop geometry or bbox even if listed
+                    name.Equals(GeometryColumn, StringComparison.OrdinalIgnoreCase) ||
+                    name.StartsWith($"{BboxColumn}_", StringComparison.OrdinalIgnoreCase) ||
+                    !dropSet.Contains(name))
+                .ToList();
+
+            // If projection would drop everything (unlikely), fall back to *
+            if (!projected.Any())
+                return null;
+
+            return string.Join(", ", projected);
+        }
+
+        /// <summary>
+        /// Builds the CREATE OR REPLACE TABLE current_table query for an ingest.
+        /// Applies the type-specific column projection, and — when an extent is
+        /// supplied — the bbox pushdown + ST_Intersects spatial filter and
+        /// ST_Intersection clipping (preserving the bbox struct when present).
+        /// </summary>
+        public static string BuildLoadQuery(string s3Path, string actualS3Type, IReadOnlyList<string> columnNames, ExtentBounds extent)
+        {
+            var projectedColumns = BuildColumnProjection(actualS3Type, columnNames);
+
+            string spatialFilter = "";
+            string extentPolygon = "";
+            if (extent != null)
+            {
+                extentPolygon = GeoParquetSql.BuildExtentPolygon(extent);
+
+                // Bbox overlap first (pushdown), then ST_Intersects so only features whose geometry
+                // actually intersects the extent are kept — prevents data extending beyond the frame.
+                spatialFilter = $@"
+                        WHERE {GeoParquetSql.BuildBboxOverlapPredicate(extent)}
+                          AND ST_Intersects(geometry, {extentPolygon})";
+            }
+
+            // Determine which columns to project (if any) while always retaining geometry
+            var projectedColumnList = projectedColumns ?? "*";
+            bool hasBboxColumn = columnNames != null && columnNames.Any(c => c.Equals(BboxColumn, StringComparison.OrdinalIgnoreCase));
+            var projectedColumnsWithoutGeometry = projectedColumns != null
+                ? string.Join(", ", projectedColumns.Split(',').Select(c => c.Trim()).Where(c => !c.Equals("geometry", StringComparison.OrdinalIgnoreCase)))
+                : "* EXCLUDE(geometry)";
+            var projectedColumnsWithoutGeometryOrBbox = projectedColumns != null
+                ? string.Join(", ", projectedColumns.Split(',').Select(c => c.Trim()).Where(c =>
+                    !c.Equals("geometry", StringComparison.OrdinalIgnoreCase) &&
+                    !c.Equals(BboxColumn, StringComparison.OrdinalIgnoreCase)))
+                : (hasBboxColumn ? "* EXCLUDE(geometry, bbox)" : "* EXCLUDE(geometry)");
+            if (string.IsNullOrWhiteSpace(projectedColumnsWithoutGeometry))
+                projectedColumnsWithoutGeometry = "* EXCLUDE(geometry)";
+            if (string.IsNullOrWhiteSpace(projectedColumnsWithoutGeometryOrBbox))
+                projectedColumnsWithoutGeometryOrBbox = hasBboxColumn ? "* EXCLUDE(geometry, bbox)" : "* EXCLUDE(geometry)";
+
+            if (extent != null && !string.IsNullOrEmpty(extentPolygon))
+            {
+                // Clip geometries to extent - this keeps all intersecting features but clips them to the extent
+                // Use ST_Intersection to clip, and only include features that actually intersect
+                if (hasBboxColumn)
+                {
+                    return $@"
+                        CREATE OR REPLACE TABLE current_table AS
+                        WITH clipped AS (
+                            SELECT
+                                {projectedColumnsWithoutGeometryOrBbox},
+                                CASE
+                                    WHEN ST_Intersects(geometry, {extentPolygon})
+                                    THEN ST_Intersection(geometry, {extentPolygon})
+                                    ELSE NULL
+                                END AS clipped_geometry
+                            FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
+                            {spatialFilter}
+                        )
+                        SELECT
+                            * EXCLUDE(clipped_geometry),
+                            clipped_geometry AS geometry,
+                            CASE
+                                WHEN clipped_geometry IS NOT NULL THEN struct_pack(
+                                    xmin := ST_XMin(clipped_geometry),
+                                    ymin := ST_YMin(clipped_geometry),
+                                    xmax := ST_XMax(clipped_geometry),
+                                    ymax := ST_YMax(clipped_geometry)
+                                )
+                                ELSE NULL
+                            END AS bbox
+                        FROM clipped";
+                }
+
+                return $@"
+                        CREATE OR REPLACE TABLE current_table AS
+                        SELECT
+                            {projectedColumnsWithoutGeometry},
+                            CASE
+                                WHEN ST_Intersects(geometry, {extentPolygon})
+                                THEN ST_Intersection(geometry, {extentPolygon})
+                                ELSE NULL
+                            END as geometry
+                        FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
+                        {spatialFilter}";
+            }
+
+            return $@"
+                        CREATE OR REPLACE TABLE current_table AS
+                        SELECT {projectedColumnList}
+                        FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
+                        {spatialFilter}";
+        }
+    }
+}

--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -86,9 +86,15 @@ drives the extent.
 - `DuckDBManager` (connection lifecycle + extension loading) — DONE.
   `DataProcessor` proxies `_connection`/`_isInitialized` so call sites are
   unchanged; behavior and error messages are moved verbatim.
-- Remaining: `S3Ingester`, `ParquetExporter`, `LayerManager`,
-  `GeocoderEngine`. Extract the pure parts (column projection, query text
-  builders) into testable classes as they move.
+- `S3Ingester` — pure ingest query builders extracted and DONE.
+  `Services/S3Ingester.cs` owns `BuildColumnProjection` (type-specific
+  column drops) and `BuildLoadQuery` (the `current_table` query: bbox
+  pushdown + `ST_Intersects` filter and `ST_Intersection` clipping, with
+  bbox struct repack when present). `DataProcessor.IngestFileAsync` now
+  calls it; the SQL is moved verbatim. Covered by `S3IngesterTests`. The
+  stateful S3 read (schema discovery, execution) stays in `DataProcessor`.
+- Remaining: `ParquetExporter`, `LayerManager`, `GeocoderEngine`. Extract
+  the pure parts (query text builders) into testable classes as they move.
 - Stage 3: extract `DataLoadOrchestrator` and `MfcOrchestrator` from
   `WizardDockpaneViewModel.cs` (load pipeline, bulk replacement, P/Invoke
   deletion, extent resolution; MFC creation).


### PR DESCRIPTION
## Summary

Continues the Phase 2c decomposition of `DataProcessor.cs`. After `DuckDBManager` (connection lifecycle) landed in the previous stage, this pulls the **pure ingest query construction** out of `DataProcessor.IngestFileAsync` into a new dependency-free `S3Ingester` class, following the plan's direction to "extract the pure parts (column projection, query text builders) into testable classes as they move."

## Changes

- **`Services/S3Ingester.cs`** (new) — pure, ArcGIS/DuckDB-free string builders:
  - `BuildColumnProjection` — type-specific heavy-column drops (was a private method on `DataProcessor`), driven by `OvertureSchema.ColumnExclusions`; always retains `geometry`/`bbox_*`.
  - `BuildLoadQuery` — the `CREATE OR REPLACE TABLE current_table` query, including the bbox pushdown + `ST_Intersects` spatial filter and `ST_Intersection` clipping with the `struct_pack` bbox repack when a `bbox` column is present. **SQL moved verbatim.**
- **`Services/DataProcessor.cs`** — `IngestFileAsync` now calls `S3Ingester.BuildLoadQuery(...)`; ~100 lines of inline query building removed. The stateful S3 work (schema discovery, `DESCRIBE`, execution) stays put. Removed the now-dead `BBOX_COLUMN`/`GEOMETRY_COLUMN` constants and the old private `BuildColumnProjection`.
- **`DuckDBGeoparquet.Tests`** — links `S3Ingester.cs` and `OvertureSchema.cs`; new `S3IngesterTests` covers the projection rules (drops, retention of geometry/bbox, null/unknown-type cases) and all three `BuildLoadQuery` branches (no extent → `SELECT *`/projection, extent+bbox → clip & repack, extent without bbox → clip only).
- **`docs/PHASE2_PLAN.md`** — marks `S3Ingester` builders done; remaining Stage 2 items are `ParquetExporter`, `LayerManager`, `GeocoderEngine`.

## Behavior

Pure refactor — no functional change. The generated SQL is identical to before (moved verbatim), so ingest output is unchanged; the logic is now unit-tested.

## Verification

- `dotnet test` runs the new `S3IngesterTests` in CI (this environment has no .NET SDK, so tests were not executed locally — the pure builders were reviewed against the original inline code for verbatim equivalence).
- The add-in project itself still requires an on-machine ArcGIS Pro 3.7 build to fully verify, consistent with the rest of Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU)_