### PR TITLE
docs: correct version requirements (Pro 3.7 / .NET 10) and refresh Phase 2c status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Watch the add-in in action loading Overture Maps data with incredible performanc
 
 ## Features
 
-- **Native GeoParquet Support**: Fully leverages ArcGIS Pro 3.5's native GeoParquet capabilities for optimal performance
+- **Native GeoParquet Support**: Fully leverages ArcGIS Pro's native GeoParquet capabilities for optimal performance
 - **High-Performance Processing**: Optimized data pipeline with 5-15% performance improvements and smart empty dataset handling
 - **Complex Data Preservation**: Maintains original data structure including nested types
 - **Cloud-Native Integration**: Direct access to data in S3, Azure, and other cloud storage
@@ -27,8 +27,8 @@ Watch the add-in in action loading Overture Maps data with incredible performanc
 
 ## Requirements
 
-- **ArcGIS Pro**: Version 3.5 or later (3.6+ recommended for enhanced features)
-- **.NET SDK**: Version 8.0 or later
+- **ArcGIS Pro**: Version 3.7 or later
+- **.NET SDK**: Version 10.0 or later
 - **Storage**: Minimum 4GB free disk space for temporary data
 - **Memory**: Minimum 8GB RAM (16GB recommended for large datasets)
 - **For Developers**:
@@ -194,7 +194,6 @@ Release notes are automatically generated from git commits, ensuring you always 
 - **ArcGIS Pro 3.6 Support**: Enhanced features for Pro 3.6 including cache management and compression options
 - **Compression Selection**: Choose between ZSTD (recommended), SNAPPY, or GZIP compression formats
 - **Cache Management**: View and manage Parquet cache for Pro 3.6+ users
-- **Backward Compatibility**: Maintains full support for ArcGIS Pro 3.5
 - **Automated Releases**: Fully automated CI/CD pipeline for seamless version management
 - **ArcGIS Online Publishing**: Automatic publishing to ArcGIS Marketplace with each release
 - **Performance Optimizations**: 5-15% faster processing through optimized file operations

--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -82,7 +82,7 @@ drives the extent.
 - `Services/PreviewBridge.cs` message handling is covered by tests
   (camelCase contract, wkid default, malformed-message tolerance).
 
-**Stage 2 (in progress):** split `DataProcessor.cs` behind a thin façade.
+**Stage 2 (done):** split `DataProcessor.cs` behind a thin façade.
 - `DuckDBManager` (connection lifecycle + extension loading) — DONE.
   `DataProcessor` proxies `_connection`/`_isInitialized` so call sites are
   unchanged; behavior and error messages are moved verbatim.
@@ -97,10 +97,11 @@ drives the extent.
   bbox struct repack when present). `DataProcessor.IngestFileAsync` now
   calls it; the SQL is moved verbatim. Covered by `S3IngesterTests`. The
   stateful S3 read (schema discovery, execution) stays in `DataProcessor`.
-- Remaining: `ParquetExporter`, `LayerManager`. These share
-  mutable per-load state (`_pendingLayers`, `_currentExtent`, session
-  suffix), so extract them together or thread the state through a small
-  load-context object.
+- `ParquetExporter` + `LayerManager` (GeoParquet export + map layer
+  creation/ordering/draw-order) — DONE. Extracted together because they
+  share mutable per-load state (`_pendingLayers`, `_currentExtent`, session
+  suffix); `DataProcessor` constructs both and delegates through thin
+  wrappers, so call sites are unchanged.
 - Stage 3: extract `DataLoadOrchestrator` and `MfcOrchestrator` from
   `WizardDockpaneViewModel.cs` (load pipeline, bulk replacement, P/Invoke
   deletion, extent resolution; MFC creation).


### PR DESCRIPTION
## Summary

Docs-only cleanup of stale version references I'd flagged, plus a plan-doc refresh now that the Phase 2c Stage 2 decomposition is complete on `main`.

## README

The Requirements section understated the real build target. The project targets `net10.0-windows` against `Esri.ArcGISPro.Extensions30 3.7.0.1901`, and `Config.daml` requires `desktopVersion 3.7`, but the README still said Pro 3.5 / .NET 8.

- **Requirements** → `ArcGIS Pro: Version 3.7 or later` and `.NET SDK: Version 10.0 or later` (were 3.5 / 8.0).
- Dropped the version qualifier from the native-GeoParquet feature bullet (was "ArcGIS Pro 3.5's native GeoParquet capabilities").
- Removed the now-false **"Maintains full support for ArcGIS Pro 3.5"** bullet — the add-in requires 3.7.

Left the cache-feature notes (Pro 3.6 caching behavior, cache paths) untouched: those are accurate history about when ArcGIS Pro added those capabilities, not requirement claims.

## PHASE2_PLAN.md

`ParquetExporter` and `LayerManager` now exist and are wired into `DataProcessor` (constructed in the ctor, delegated through thin wrappers), so:

- Marked Stage 2 **done** and flipped the stale "Remaining: `ParquetExporter`, `LayerManager`" bullet to DONE with a note on why they were extracted together (shared per-load state).
- Stage 3 (`DataLoadOrchestrator` / `MfcOrchestrator`) and Phase 2d remain as the open work.

## Behavior

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU)_