### PR TITLE
refactor: extract ParquetFileDeleter (Phase 2c stage 3, slice 1)

### DIFF
--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -16,6 +16,7 @@
 		<Compile Include="..\Services\GeocodeTextNormalizer.cs" Link="Linked\GeocodeTextNormalizer.cs" />
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
 		<Compile Include="..\Services\S3Ingester.cs" Link="Linked\S3Ingester.cs" />
+		<Compile Include="..\Services\ParquetFileDeleter.cs" Link="Linked\ParquetFileDeleter.cs" />
 		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/DuckDBGeoparquet.Tests/ParquetFileDeleterTests.cs
+++ b/DuckDBGeoparquet.Tests/ParquetFileDeleterTests.cs
@@ -1,0 +1,74 @@
+using DuckDBGeoparquet.Services;
+using System;
+using System.IO;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class ParquetFileDeleterTests
+    {
+        [Theory]
+        [InlineData(32, true)]  // ERROR_SHARING_VIOLATION
+        [InlineData(33, true)]  // ERROR_LOCK_VIOLATION
+        [InlineData(5, true)]   // ERROR_ACCESS_DENIED
+        [InlineData(2, false)]  // ERROR_FILE_NOT_FOUND
+        [InlineData(0, false)]  // success / no error
+        public void IsLockWin32Error_TreatsInUseCodesAsLocked(int code, bool expected)
+        {
+            Assert.Equal(expected, ParquetFileDeleter.IsLockWin32Error(code));
+        }
+
+        [Fact]
+        public void TryDelete_MissingFile_ReportsDeleted()
+        {
+            // No P/Invoke: File.Exists is false so it returns before touching kernel32.
+            string path = Path.Combine(Path.GetTempPath(), $"pfd_missing_{Guid.NewGuid():N}.parquet");
+            Assert.False(File.Exists(path));
+            Assert.Equal(FileDeleteResult.Deleted, ParquetFileDeleter.TryDelete(path));
+        }
+
+        [Fact]
+        public void TryDelete_ExistingUnlockedFile_DeletesIt()
+        {
+            if (!OperatingSystem.IsWindows()) return; // kernel32 path; CI runs on Windows
+
+            string path = Path.Combine(Path.GetTempPath(), $"pfd_del_{Guid.NewGuid():N}.parquet");
+            File.WriteAllText(path, "x");
+            try
+            {
+                Assert.Equal(FileDeleteResult.Deleted, ParquetFileDeleter.TryDelete(path));
+                Assert.False(File.Exists(path));
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void TryDelete_LockedFile_ReportsLocked_ThenDeletesOnceReleased()
+        {
+            if (!OperatingSystem.IsWindows()) return; // kernel32 path; CI runs on Windows
+
+            string path = Path.Combine(Path.GetTempPath(), $"pfd_lock_{Guid.NewGuid():N}.parquet");
+            File.WriteAllText(path, "x");
+            try
+            {
+                using (new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                {
+                    // Held open with no sharing → the delete open fails with a
+                    // sharing violation, reported as Locked rather than throwing.
+                    Assert.Equal(FileDeleteResult.Locked, ParquetFileDeleter.TryDelete(path));
+                }
+
+                // Handle released → deletes cleanly.
+                Assert.Equal(FileDeleteResult.Deleted, ParquetFileDeleter.TryDelete(path));
+                Assert.False(File.Exists(path));
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+    }
+}

--- a/Services/ParquetFileDeleter.cs
+++ b/Services/ParquetFileDeleter.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>Outcome of a best-effort parquet file delete.</summary>
+    public enum FileDeleteResult
+    {
+        Deleted,
+        Locked,
+        Failed
+    }
+
+    /// <summary>
+    /// Best-effort deletion of on-disk parquet files, distinguishing a file
+    /// that is locked (held open by ArcGIS Pro and will free up later) from
+    /// one that genuinely failed to delete. Uses the Win32 API directly so a
+    /// lock is reported as a clean status instead of surfacing as an
+    /// exception. No ArcGIS dependencies, so it is unit-testable.
+    /// Extracted from WizardDockpaneViewModel (Phase 2c stage 3).
+    /// </summary>
+    public static class ParquetFileDeleter
+    {
+        private const uint FILE_DELETE_ACCESS = 0x00010000;
+        private const int ERROR_SHARING_VIOLATION = 32;
+        private const int ERROR_LOCK_VIOLATION = 33;
+        private const int ERROR_ACCESS_DENIED = 5;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern SafeFileHandle CreateFileW(
+            string lpFileName,
+            uint dwDesiredAccess,
+            FileShare dwShareMode,
+            IntPtr lpSecurityAttributes,
+            FileMode dwCreationDisposition,
+            FileAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool DeleteFileW(string lpFileName);
+
+        /// <summary>
+        /// Attempts to delete <paramref name="filePath"/> without throwing.
+        /// A missing file counts as already <see cref="FileDeleteResult.Deleted"/>.
+        /// A sharing/lock/access-denied error is reported as
+        /// <see cref="FileDeleteResult.Locked"/>; any other failure as
+        /// <see cref="FileDeleteResult.Failed"/>.
+        /// </summary>
+        public static FileDeleteResult TryDelete(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                return FileDeleteResult.Deleted;
+            }
+
+            using (var handle = CreateFileW(
+                filePath,
+                FILE_DELETE_ACCESS,
+                FileShare.None,
+                IntPtr.Zero,
+                FileMode.Open,
+                FileAttributes.Normal,
+                IntPtr.Zero))
+            {
+                if (handle.IsInvalid)
+                {
+                    int openError = Marshal.GetLastWin32Error();
+                    return IsLockWin32Error(openError) ? FileDeleteResult.Locked : FileDeleteResult.Failed;
+                }
+            }
+
+            if (DeleteFileW(filePath))
+            {
+                return FileDeleteResult.Deleted;
+            }
+
+            int deleteError = Marshal.GetLastWin32Error();
+            return IsLockWin32Error(deleteError) ? FileDeleteResult.Locked : FileDeleteResult.Failed;
+        }
+
+        /// <summary>True for Win32 error codes that mean "the file is in use", not a hard failure.</summary>
+        internal static bool IsLockWin32Error(int errorCode)
+        {
+            return errorCode == ERROR_SHARING_VIOLATION
+                   || errorCode == ERROR_LOCK_VIOLATION
+                   || errorCode == ERROR_ACCESS_DENIED;
+        }
+    }
+}

--- a/Views/WizardDockpaneViewModel.cs
+++ b/Views/WizardDockpaneViewModel.cs
@@ -37,11 +37,6 @@ namespace DuckDBGeoparquet.Views
         private const string RELEASE_URL = "https://labs.overturemaps.org/data/releases.json";
         private const string S3_BASE_PATH = "s3://overturemaps-us-west-2/release";
 
-        private const uint FILE_DELETE_ACCESS = 0x00010000;
-        private const int ERROR_SHARING_VIOLATION = 32;
-        private const int ERROR_LOCK_VIOLATION = 33;
-        private const int ERROR_ACCESS_DENIED = 5;
-
         // Add CancellationTokenSource for cancelling operations
         private CancellationTokenSource _cts;
         private bool _skipExistingData;
@@ -50,19 +45,6 @@ namespace DuckDBGeoparquet.Views
         {
             PropertyNameCaseInsensitive = true
         };
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern SafeFileHandle CreateFileW(
-            string lpFileName,
-            uint dwDesiredAccess,
-            FileShare dwShareMode,
-            IntPtr lpSecurityAttributes,
-            FileMode dwCreationDisposition,
-            FileAttributes dwFlagsAndAttributes,
-            IntPtr hTemplateFile);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool DeleteFileW(string lpFileName);
 
         // Centralized logic for Default MFC Base Path
         private static string DeterminedDefaultMfcBasePath
@@ -560,7 +542,7 @@ namespace DuckDBGeoparquet.Views
 
                             foreach (var file in Directory.EnumerateFiles(folderPath, "*.parquet", SearchOption.AllDirectories))
                             {
-                                var deleteResult = TryDeleteParquetFileQuiet(file);
+                                var deleteResult = ParquetFileDeleter.TryDelete(file);
                                 switch (deleteResult)
                                 {
                                     case FileDeleteResult.Deleted:
@@ -633,52 +615,6 @@ namespace DuckDBGeoparquet.Views
                 StatusText = "Cleanup completed with warnings. Continuing with data load...";
                 System.Diagnostics.Debug.WriteLine($"Error in PerformBulkDataReplacementAsync: {ex.Message}");
             }
-        }
-
-        private enum FileDeleteResult
-        {
-            Deleted,
-            Locked,
-            Failed
-        }
-
-        private static FileDeleteResult TryDeleteParquetFileQuiet(string filePath)
-        {
-            if (!File.Exists(filePath))
-            {
-                return FileDeleteResult.Deleted;
-            }
-
-            using (var handle = CreateFileW(
-                filePath,
-                FILE_DELETE_ACCESS,
-                FileShare.None,
-                IntPtr.Zero,
-                FileMode.Open,
-                FileAttributes.Normal,
-                IntPtr.Zero))
-            {
-                if (handle.IsInvalid)
-                {
-                    int openError = Marshal.GetLastWin32Error();
-                    return IsLockWin32Error(openError) ? FileDeleteResult.Locked : FileDeleteResult.Failed;
-                }
-            }
-
-            if (DeleteFileW(filePath))
-            {
-                return FileDeleteResult.Deleted;
-            }
-
-            int deleteError = Marshal.GetLastWin32Error();
-            return IsLockWin32Error(deleteError) ? FileDeleteResult.Locked : FileDeleteResult.Failed;
-        }
-
-        private static bool IsLockWin32Error(int errorCode)
-        {
-            return errorCode == ERROR_SHARING_VIOLATION
-                   || errorCode == ERROR_LOCK_VIOLATION
-                   || errorCode == ERROR_ACCESS_DENIED;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

First incremental slice of **Phase 2c Stage 3** — pulling the load pipeline out of `WizardDockpaneViewModel`. (Note: the *MfcOrchestrator* half of Stage 3 is already effectively done — MFC creation lives in the standalone `MfcDockpaneViewModel` and the wizard no longer creates MFCs — so Stage 3 is really just the `DataLoadOrchestrator`.)

This slice extracts the most self-contained, testable unit: the best-effort parquet **file deletion** logic (kernel32 P/Invoke + lock detection).

## Changes

- **`Services/ParquetFileDeleter.cs`** (new) — dependency-free:
  - `FileDeleteResult` enum, the `CreateFileW`/`DeleteFileW` P/Invoke, the Win32 error constants, `TryDelete` (renamed from `TryDeleteParquetFileQuiet`), and `IsLockWin32Error`. **Logic moved verbatim.**
  - Distinguishes a *locked* file (held open by ArcGIS Pro — will free up later) from a genuine failure, so a lock reports as a clean status instead of throwing.
- **`Views/WizardDockpaneViewModel.cs`** — removed the constants, both P/Invokes, the enum, and the two methods; the bulk-cleanup loop now calls `ParquetFileDeleter.TryDelete(file)`. Otherwise unchanged.
- **`DuckDBGeoparquet.Tests`** — links `ParquetFileDeleter.cs`; new `ParquetFileDeleterTests` covers the lock-code classification and the missing / unlocked / locked delete paths (P/Invoke tests are guarded to run on Windows, matching CI).

## Behavior

Pure refactor — no functional change. The generated behavior is identical (logic moved verbatim); it's now isolated and unit-tested.

## Verification

Verified via CI (Windows MSBuild + `dotnet test`) — this container has no .NET/ArcGIS SDK, so the extraction was reviewed against the original for verbatim equivalence.

## Follow-ups (rest of Stage 3, later slices)

- Extent resolution (`GetLoadExtentAsync`) — pure core into a testable helper.
- The bulk-replacement / layer-removal pipeline (`PerformBulkDataReplacementAsync`, `RemoveLayersUsingFolderAsync`) and `LoadOvertureDataAsync` into a `DataLoadOrchestrator`.
- `docs/PHASE2_PLAN.md` Stage 3 status update (held back here to avoid conflicting with the in-flight docs PR #15, which edits the same section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU)_