### PR TITLE
refactor: extract ExtentResolution (Phase 2c stage 3, slice 2)

### DIFF
--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -17,6 +17,7 @@
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
 		<Compile Include="..\Services\S3Ingester.cs" Link="Linked\S3Ingester.cs" />
 		<Compile Include="..\Services\ParquetFileDeleter.cs" Link="Linked\ParquetFileDeleter.cs" />
+		<Compile Include="..\Services\ExtentResolution.cs" Link="Linked\ExtentResolution.cs" />
 		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/DuckDBGeoparquet.Tests/ExtentResolutionTests.cs
+++ b/DuckDBGeoparquet.Tests/ExtentResolutionTests.cs
@@ -1,0 +1,37 @@
+using DuckDBGeoparquet.Services;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class ExtentResolutionTests
+    {
+        [Theory]
+        // Map wins whenever "use current map extent" is on and a map is active,
+        // even if a custom extent is also set.
+        [InlineData(true, true, false, false, ExtentSource.Map)]
+        [InlineData(true, true, true, true, ExtentSource.Map)]
+        // No active map (or toggle off) falls back to a set custom extent.
+        [InlineData(true, false, true, true, ExtentSource.Custom)]
+        [InlineData(false, true, true, true, ExtentSource.Custom)]
+        [InlineData(false, false, true, true, ExtentSource.Custom)]
+        // Neither source available → None.
+        [InlineData(true, false, true, false, ExtentSource.None)]  // custom flag on but no extent
+        [InlineData(true, false, false, true, ExtentSource.None)]  // custom extent present but flag off
+        [InlineData(false, false, false, false, ExtentSource.None)]
+        public void ChooseSource_FollowsMapThenCustomPrecedence(
+            bool useMap, bool hasMap, bool useCustom, bool hasCustom, ExtentSource expected)
+        {
+            Assert.Equal(expected, ExtentResolution.ChooseSource(useMap, hasMap, useCustom, hasCustom));
+        }
+
+        [Theory]
+        [InlineData(4326, false)]     // already WGS84
+        [InlineData(3857, true)]      // Web Mercator
+        [InlineData(102100, true)]    // Esri Web Mercator
+        [InlineData(null, true)]      // unknown SR → project defensively
+        public void NeedsProjectionToWgs84_TrueUnlessAlready4326(int? wkid, bool expected)
+        {
+            Assert.Equal(expected, ExtentResolution.NeedsProjectionToWgs84(wkid));
+        }
+    }
+}

--- a/Services/ExtentResolution.cs
+++ b/Services/ExtentResolution.cs
@@ -1,0 +1,42 @@
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>Which configured source a data load takes its extent from.</summary>
+    public enum ExtentSource
+    {
+        None,
+        Map,
+        Custom
+    }
+
+    /// <summary>
+    /// Pure extent-resolution helpers extracted from WizardDockpaneViewModel
+    /// (Phase 2c stage 3). No ArcGIS dependencies: the ViewModel still reads
+    /// the live map / custom <c>Envelope</c> and does the actual projection,
+    /// but the source-selection precedence and the "does this need projecting
+    /// to WGS84?" decision live here so they are unit-testable.
+    /// </summary>
+    public static class ExtentResolution
+    {
+        /// <summary>WKID of WGS84 (EPSG:4326) — the SR the load pipeline filters in.</summary>
+        public const int Wgs84Wkid = 4326;
+
+        /// <summary>
+        /// Mirrors the ViewModel's precedence: the current map extent wins when
+        /// "use current map extent" is on and a map is active; otherwise the
+        /// custom extent is used when one is set; otherwise there is no extent.
+        /// </summary>
+        public static ExtentSource ChooseSource(bool useCurrentMapExtent, bool hasActiveMap, bool useCustomExtent, bool hasCustomExtent)
+        {
+            if (useCurrentMapExtent && hasActiveMap) return ExtentSource.Map;
+            if (useCustomExtent && hasCustomExtent) return ExtentSource.Custom;
+            return ExtentSource.None;
+        }
+
+        /// <summary>
+        /// True when an extent in the given spatial reference must be projected
+        /// to WGS84 before use. A null WKID (unknown SR) is treated as needing
+        /// projection, matching the original guard.
+        /// </summary>
+        public static bool NeedsProjectionToWgs84(int? wkid) => wkid != Wgs84Wkid;
+    }
+}

--- a/Views/WizardDockpaneViewModel.cs
+++ b/Views/WizardDockpaneViewModel.cs
@@ -759,56 +759,58 @@ namespace DuckDBGeoparquet.Views
             _savedViewExtentForRestore = null;
             await QueuedTask.Run(() =>
             {
-                SpatialReference wgs84 = SpatialReferenceBuilder.CreateSpatialReference(4326);
+                SpatialReference wgs84 = SpatialReferenceBuilder.CreateSpatialReference(ExtentResolution.Wgs84Wkid);
 
-                if (UseCurrentMapExtent && MapView.Active != null)
+                switch (ExtentResolution.ChooseSource(UseCurrentMapExtent, MapView.Active != null, UseCustomExtent, CustomExtent != null))
                 {
-                    Envelope mapExtent = MapView.Active.Extent;
-                    if (mapExtent != null)
+                    case ExtentSource.Map:
                     {
-                        // Save view extent so we can restore it after adding layers (prevents zoom-out)
-                        _savedViewExtentForRestore = EnvelopeBuilderEx.CreateEnvelope(mapExtent.XMin, mapExtent.YMin, mapExtent.XMax, mapExtent.YMax, mapExtent.SpatialReference);
-                        if (mapExtent.SpatialReference == null || mapExtent.SpatialReference.Wkid != 4326)
+                        Envelope mapExtent = MapView.Active.Extent;
+                        if (mapExtent != null)
                         {
-                            AddToLog($"Map extent SR is {mapExtent.SpatialReference?.Wkid.ToString() ?? "null"}, projecting to WGS84 (4326).");
-                            try
+                            // Save view extent so we can restore it after adding layers (prevents zoom-out)
+                            _savedViewExtentForRestore = EnvelopeBuilderEx.CreateEnvelope(mapExtent.XMin, mapExtent.YMin, mapExtent.XMax, mapExtent.YMax, mapExtent.SpatialReference);
+                            if (ExtentResolution.NeedsProjectionToWgs84(mapExtent.SpatialReference?.Wkid))
                             {
-                                extent = GeometryEngine.Instance.Project(mapExtent, wgs84) as Envelope;
-                                if (extent == null)
+                                AddToLog($"Map extent SR is {mapExtent.SpatialReference?.Wkid.ToString() ?? "null"}, projecting to WGS84 (4326).");
+                                try
                                 {
-                                    AddToLog("Warning: Map extent projection to WGS84 resulted in null. Original extent might be invalid or projection failed.");
+                                    extent = GeometryEngine.Instance.Project(mapExtent, wgs84) as Envelope;
+                                    if (extent == null)
+                                    {
+                                        AddToLog("Warning: Map extent projection to WGS84 resulted in null. Original extent might be invalid or projection failed.");
+                                        extent = mapExtent;
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    AddToLog($"Error projecting map extent: {ex.Message}. Using original extent values, which might be incorrect for filtering.");
+                                    System.Diagnostics.Debug.WriteLine($"Error projecting map extent: {ex.Message}");
                                     extent = mapExtent;
                                 }
                             }
-                            catch (Exception ex)
+                            else
                             {
-                                AddToLog($"Error projecting map extent: {ex.Message}. Using original extent values, which might be incorrect for filtering.");
-                                System.Diagnostics.Debug.WriteLine($"Error projecting map extent: {ex.Message}");
+                                AddToLog("Map extent is already in WGS84.");
                                 extent = mapExtent;
                             }
+                            AddToLog($"Using WGS84 extent from map: {extent.XMin:F6}, {extent.YMin:F6}, {extent.XMax:F6}, {extent.YMax:F6}");
+                            System.Diagnostics.Debug.WriteLine($"[GetLoadExtentAsync] WGS84 extent from map (MapView.Active.Extent): {extent.XMin}, {extent.YMin}, {extent.XMax}, {extent.YMax}");
                         }
                         else
                         {
-                            AddToLog("Map extent is already in WGS84.");
-                            extent = mapExtent;
+                            AddToLog("Map extent is null.");
                         }
-                        AddToLog($"Using WGS84 extent from map: {extent.XMin:F6}, {extent.YMin:F6}, {extent.XMax:F6}, {extent.YMax:F6}");
-                        System.Diagnostics.Debug.WriteLine($"[GetLoadExtentAsync] WGS84 extent from map (MapView.Active.Extent): {extent.XMin}, {extent.YMin}, {extent.XMax}, {extent.YMax}");
+                        break;
                     }
-                    else
-                    {
-                        AddToLog("Map extent is null.");
-                    }
-                }
-                else if (UseCustomExtent && CustomExtent != null)
-                {
-                    extent = CustomExtent;
-                    AddToLog($"Using custom WGS84 extent: {extent.XMin:F6}, {extent.YMin:F6}, {extent.XMax:F6}, {extent.YMax:F6}");
-                    System.Diagnostics.Debug.WriteLine($"Using custom WGS84 extent: {extent.XMin}, {extent.YMin}, {extent.XMax}, {extent.YMax}");
-                }
-                else
-                {
-                    AddToLog("No extent specified or available for filtering.");
+                    case ExtentSource.Custom:
+                        extent = CustomExtent;
+                        AddToLog($"Using custom WGS84 extent: {extent.XMin:F6}, {extent.YMin:F6}, {extent.XMax:F6}, {extent.YMax:F6}");
+                        System.Diagnostics.Debug.WriteLine($"Using custom WGS84 extent: {extent.XMin}, {extent.YMin}, {extent.XMax}, {extent.YMax}");
+                        break;
+                    default:
+                        AddToLog("No extent specified or available for filtering.");
+                        break;
                 }
             });
             return extent;


### PR DESCRIPTION
## Summary

Second incremental slice of **Phase 2c Stage 3** (the `DataLoadOrchestrator` extraction from `WizardDockpaneViewModel`). This one pulls the pure decisions out of `GetLoadExtentAsync`.

## Changes

- **`Services/ExtentResolution.cs`** (new) — dependency-free:
  - `ExtentSource` enum + `ChooseSource(...)` — the map-extent → custom-extent → none source precedence.
  - `NeedsProjectionToWgs84(int? wkid)` — whether an extent's SR needs projecting to WGS84; a null/unknown SR is treated as needing projection, matching the original `SR == null || SR.Wkid != 4326` guard.
  - `Wgs84Wkid` const (4326) — now the single source for that magic number.
- **`Views/WizardDockpaneViewModel.cs`** — `GetLoadExtentAsync` keeps every ArcGIS call (`Envelope`, `MapView.Active`, `GeometryEngine.Project`, `EnvelopeBuilderEx`) and all log messages **verbatim**; the `if/else-if/else` chain becomes a `switch` over `ChooseSource`, and the SR guard now calls `NeedsProjectionToWgs84`.
- **`DuckDBGeoparquet.Tests`** — links `ExtentResolution.cs`; new `ExtentResolutionTests` pins the source precedence (incl. map-over-custom) and the projection rule across 4326 / Web Mercator / Esri Web Mercator / null.

## Behavior

Pure refactor — no functional change. The control flow and messages are identical; the decision logic is now explicit and unit-tested.

## Verification

Verified via CI (Windows MSBuild + `dotnet test`) — no .NET/ArcGIS SDK in this container, so the restructure was checked line-by-line against the original for equivalence.

## Relationship to other PRs

Independent of PR #16 (ParquetFileDeleter, slice 1) — different regions of the same file, no overlap; both branch from `main`. Plan-doc update still deferred until the in-flight docs PR #15 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU)_