### PR TITLE
fix: MFC 'previously loaded data' source path (+ dedupe data-path logic)

### DIFF
--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -18,6 +18,7 @@
 		<Compile Include="..\Services\S3Ingester.cs" Link="Linked\S3Ingester.cs" />
 		<Compile Include="..\Services\ParquetFileDeleter.cs" Link="Linked\ParquetFileDeleter.cs" />
 		<Compile Include="..\Services\ExtentResolution.cs" Link="Linked\ExtentResolution.cs" />
+		<Compile Include="..\Services\OvertureDataPaths.cs" Link="Linked\OvertureDataPaths.cs" />
 		<Compile Include="..\Services\PreviewBridge.cs" Link="Linked\PreviewBridge.cs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/DuckDBGeoparquet.Tests/OvertureDataPathsTests.cs
+++ b/DuckDBGeoparquet.Tests/OvertureDataPathsTests.cs
@@ -1,0 +1,67 @@
+using DuckDBGeoparquet.Services;
+using System;
+using System.IO;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class OvertureDataPathsTests
+    {
+        [Fact]
+        public void ResolveNewestReleaseFolder_ReturnsNull_ForMissingDirectory()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), $"odp_missing_{Guid.NewGuid():N}");
+            Assert.Null(OvertureDataPaths.ResolveNewestReleaseFolder(missing));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ResolveNewestReleaseFolder_ReturnsNull_ForBlankInput(string input)
+        {
+            Assert.Null(OvertureDataPaths.ResolveNewestReleaseFolder(input));
+        }
+
+        [Fact]
+        public void ResolveNewestReleaseFolder_ReturnsNull_WhenNoSubfolders()
+        {
+            string dir = CreateTempDir();
+            try
+            {
+                // A file (not a folder) present — still no release subfolders.
+                File.WriteAllText(Path.Combine(dir, "note.txt"), "x");
+                Assert.Null(OvertureDataPaths.ResolveNewestReleaseFolder(dir));
+            }
+            finally { Directory.Delete(dir, recursive: true); }
+        }
+
+        [Fact]
+        public void ResolveNewestReleaseFolder_PicksMostRecentlyModifiedSubfolder()
+        {
+            string dataDir = CreateTempDir();
+            try
+            {
+                string older = Directory.CreateDirectory(Path.Combine(dataDir, "2026-05-01.0")).FullName;
+                string newer = Directory.CreateDirectory(Path.Combine(dataDir, "2026-06-17.0")).FullName;
+                string oldest = Directory.CreateDirectory(Path.Combine(dataDir, "2026-04-01.0")).FullName;
+
+                // Set explicit write times so the assertion doesn't depend on creation order.
+                var baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                Directory.SetLastWriteTimeUtc(oldest, baseTime);
+                Directory.SetLastWriteTimeUtc(older, baseTime.AddDays(10));
+                Directory.SetLastWriteTimeUtc(newer, baseTime.AddDays(20));
+
+                Assert.Equal(newer, OvertureDataPaths.ResolveNewestReleaseFolder(dataDir));
+            }
+            finally { Directory.Delete(dataDir, recursive: true); }
+        }
+
+        private static string CreateTempDir()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), $"odp_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+    }
+}

--- a/Services/OvertureDataPaths.cs
+++ b/Services/OvertureDataPaths.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Linq;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Pure filesystem helpers for locating the add-in's loaded data on disk.
+    /// No ArcGIS dependencies (the project-root lookup lives in
+    /// <see cref="ProjectDataLocator"/>), so this is unit-testable.
+    /// </summary>
+    public static class OvertureDataPaths
+    {
+        /// <summary>
+        /// Returns the most recently modified immediate subfolder of
+        /// <paramref name="dataDirectory"/> — i.e. the newest loaded Overture
+        /// release folder, which is the one holding the per-type subfolders
+        /// that CreateBdc consumes. Returns null when the directory is missing
+        /// or has no subfolders.
+        /// </summary>
+        public static string ResolveNewestReleaseFolder(string dataDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(dataDirectory) || !Directory.Exists(dataDirectory))
+                return null;
+
+            return new DirectoryInfo(dataDirectory)
+                .GetDirectories()
+                .OrderByDescending(d => d.LastWriteTimeUtc)
+                .Select(d => d.FullName)
+                .FirstOrDefault();
+        }
+    }
+}

--- a/Services/OvertureGeocoderService.cs
+++ b/Services/OvertureGeocoderService.cs
@@ -212,29 +212,10 @@ namespace DuckDBGeoparquet.Services
 
         private static string ResolveDataRootPath()
         {
-            try
-            {
-                var project = Project.Current;
-                if (project != null && !string.IsNullOrWhiteSpace(project.HomeFolderPath))
-                {
-                    return Path.Combine(project.HomeFolderPath, DataSubfolder, "Data");
-                }
-
-                if (project != null && !string.IsNullOrWhiteSpace(project.Path))
-                {
-                    string projectDir = Path.GetDirectoryName(project.Path);
-                    if (!string.IsNullOrWhiteSpace(projectDir))
-                    {
-                        return Path.Combine(projectDir, DataSubfolder, "Data");
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"ResolveDataRootPath failed: {ex.Message}");
-            }
-
-            return null;
+            // Shared project-root lookup; the geocoder treats "no project" as null
+            // (skip geocoding) rather than falling back to MyDocuments.
+            string root = ProjectDataLocator.GetProjectRoot();
+            return root == null ? null : Path.Combine(root, DataSubfolder, "Data");
         }
 
         public void Dispose()

--- a/Services/ProjectDataLocator.cs
+++ b/Services/ProjectDataLocator.cs
@@ -1,0 +1,71 @@
+using ArcGIS.Desktop.Core;
+using DuckDBGeoparquet.Models;
+using System;
+using System.IO;
+
+namespace DuckDBGeoparquet.Services
+{
+    /// <summary>
+    /// Single source of truth for where the add-in stores loaded data, replacing
+    /// three drifted copies (the wizard's default MFC base path, the geocoder's
+    /// data-root lookup, and the MFC dockpane's source path). The shared piece is
+    /// the ArcGIS project-root lookup; each caller keeps its own fallback:
+    /// the wizard/MFC fall back to MyDocuments, the geocoder treats "no project"
+    /// as null.
+    /// </summary>
+    public static class ProjectDataLocator
+    {
+        /// <summary>
+        /// The current project's root — its Home Folder, or the folder holding
+        /// the .aprx if no Home Folder is set. Null when no project is open (or
+        /// the lookup throws), so callers can choose their own fallback.
+        /// </summary>
+        public static string GetProjectRoot()
+        {
+            try
+            {
+                var project = Project.Current;
+                if (project != null && !string.IsNullOrWhiteSpace(project.HomeFolderPath))
+                {
+                    return project.HomeFolderPath;
+                }
+                if (project != null && !string.IsNullOrWhiteSpace(project.Path))
+                {
+                    string projectDir = Path.GetDirectoryName(project.Path);
+                    if (!string.IsNullOrWhiteSpace(projectDir))
+                        return projectDir;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ProjectDataLocator.GetProjectRoot failed: {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The add-in's data base folder (<c>&lt;root&gt;\OvertureProAddinData</c>),
+        /// falling back to MyDocuments when no project is open.
+        /// </summary>
+        public static string GetAddinDataBase()
+        {
+            string root = GetProjectRoot()
+                ?? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            return Path.Combine(root, AddinConstants.DataSubfolder);
+        }
+
+        /// <summary>
+        /// The directory holding per-release data folders
+        /// (<c>&lt;root&gt;\OvertureProAddinData\Data</c>).
+        /// </summary>
+        public static string GetDataDirectory() => Path.Combine(GetAddinDataBase(), "Data");
+
+        /// <summary>
+        /// The most recently loaded release folder under <see cref="GetDataDirectory"/>,
+        /// or null if nothing has been loaded. This is the folder CreateBdc needs
+        /// (it directly contains the per-type subfolders).
+        /// </summary>
+        public static string GetNewestLoadedReleaseFolder() =>
+            OvertureDataPaths.ResolveNewestReleaseFolder(GetDataDirectory());
+    }
+}

--- a/Views/MfcDockpaneViewModel.cs
+++ b/Views/MfcDockpaneViewModel.cs
@@ -21,9 +21,9 @@ namespace DuckDBGeoparquet.Views
             BrowseMfcLocationCommand = new RelayCommand(() => BrowseMfcLocation());
             CreateMfcCommand = new RelayCommand(async () => await CreateMfcAsync(), () => CanCreateMfc());
 
-            // Initialize default output
-            var defaultBasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "ArcGIS", "Projects", "OvertureProAddinData");
-            MfcOutputPath = Path.Combine(defaultBasePath, "Connections");
+            // Default output under the add-in's data base, matching the wizard
+            // (<project>\OvertureProAddinData\Connections, MyDocuments fallback).
+            MfcOutputPath = Path.Combine(ProjectDataLocator.GetAddinDataBase(), "Connections");
         }
 
         protected override Task InitializeAsync()
@@ -159,15 +159,12 @@ namespace DuckDBGeoparquet.Views
                 ((RelayCommand)CreateMfcCommand).RaiseCanExecuteChanged();
                 StatusText = "Creating Multifile Feature Connection (MFC)...";
 
-                string sourceDataPath = string.Empty;
+                string sourceDataPath;
                 if (UsePreviouslyLoadedData)
                 {
-                    var defaultBasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "ArcGIS", "Projects", "OvertureProAddinData");
-                    sourceDataPath = Path.Combine(defaultBasePath, "Data", "latest");
-                    if (!Directory.Exists(sourceDataPath))
-                    {
-                        sourceDataPath = Path.Combine(defaultBasePath, "Data");
-                    }
+                    // Newest release folder under <project>\OvertureProAddinData\Data —
+                    // the folder that directly holds the per-type subfolders CreateBdc needs.
+                    sourceDataPath = ProjectDataLocator.GetNewestLoadedReleaseFolder();
                 }
                 else
                 {

--- a/Views/WizardDockpaneViewModel.cs
+++ b/Views/WizardDockpaneViewModel.cs
@@ -46,35 +46,9 @@ namespace DuckDBGeoparquet.Views
             PropertyNameCaseInsensitive = true
         };
 
-        // Centralized logic for Default MFC Base Path
-        private static string DeterminedDefaultMfcBasePath
-        {
-            get
-            {
-                try
-                {
-                    var project = Project.Current;
-                    if (project != null && !string.IsNullOrEmpty(project.HomeFolderPath))
-                    {
-                        // Use the project's Home Folder Path
-                        return Path.Combine(project.HomeFolderPath, AddinConstants.DataSubfolder);
-                    }
-                    // Fallback if HomeFolderPath is not available but project path is (less ideal)
-                    else if (project != null && !string.IsNullOrEmpty(project.Path))
-                    {
-                        string projectDir = Path.GetDirectoryName(project.Path);
-                        if (!string.IsNullOrEmpty(projectDir))
-                            return Path.Combine(projectDir, AddinConstants.DataSubfolder);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine($"Error getting project home/path for DefaultMfcBasePath: {ex.Message}");
-                }
-                // Fallback to MyDocuments if project path cannot be determined
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), AddinConstants.DataSubfolder);
-            }
-        }
+        // Default MFC base path: <project>\OvertureProAddinData (MyDocuments fallback).
+        // Shared with the geocoder and the MFC dockpane via ProjectDataLocator.
+        private static string DeterminedDefaultMfcBasePath => ProjectDataLocator.GetAddinDataBase();
 
         // Store original Overture S3 theme structure
         private readonly Dictionary<string, string> _overtureS3ThemeTypes = new()


### PR DESCRIPTION
## Summary

Fixes the `DirectoryNotFoundException` when creating an MFC via **Use previously loaded data**, surfaced during on-machine smoke testing:

```
Error creating MFC: Source data directory not found:
C:\Users\...\Documents\ArcGIS\Projects\OvertureProAddinData\Data
```

### Root cause

`MfcDockpaneViewModel` hardcoded `MyDocuments\ArcGIS\Projects\OvertureProAddinData\Data[\latest]`, but the wizard actually writes to `<projectHome>\OvertureProAddinData\Data\<release>\<type>\*.parquet`. Three mismatches: wrong base (ignored the current **project's home folder**), a `latest` subfolder that's never created, and one level too shallow — the per-type folders (`address/`, `building/`…) live under the **release** folder, which is what `CreateBdc` needs.

This data-path logic was **duplicated three ways** (wizard default base, geocoder data root, MFC source) and the MFC copy had drifted — the direct cause of the bug.

### Fix (shared helper, per review decision)

- **`Services/ProjectDataLocator.cs`** (ArcGIS) — one project-root lookup (Home Folder → `.aprx` dir), plus `GetAddinDataBase` / `GetDataDirectory` / `GetNewestLoadedReleaseFolder`.
- **`Services/OvertureDataPaths.cs`** (pure, unit-tested) — `ResolveNewestReleaseFolder` picks the most recently modified release subfolder (the "previously loaded data").
- **Wizard** `DeterminedDefaultMfcBasePath` and **geocoder** `ResolveDataRootPath` now delegate to the shared lookup, each keeping its **own** fallback (MyDocuments vs null) — behavior preserved.
- **MFC dockpane** uses `GetNewestLoadedReleaseFolder()` for the source and `GetAddinDataBase()` for the default output location.

### Tests

`OvertureDataPathsTests` covers `ResolveNewestReleaseFolder`: newest-by-mtime selection, missing dir → null, blank input → null, no-subfolders → null.

### Scope note

Independent of the Stage 3 refactor PRs (#16/#17) — this is a pre-existing bug; those refactors don't touch MFC creation. The smoke-test log confirmed `ParquetFileDeleter` and `ExtentResolution` both work; this was the only failure.

### Verification

CI (Windows MSBuild + `dotnet test`). Delegations were checked line-by-line for behavior equivalence; can't build locally (no ArcGIS SDK in the container). Worth re-running the MFC smoke test on-machine once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApEqtDAmFJtFY7abVozGmU)_