### PR TITLE
[codex] Add GERSify field mapping preview

### DIFF
--- a/Config.daml
+++ b/Config.daml
@@ -41,7 +41,7 @@
 				</button>
 				<button id="DuckDBGeoparquet_Views_GersifyDockpane_ShowButton" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="F" extendedCaption="Match User Data to Overture GERS IDs">
 					<tooltip heading="GERSify Data">
-                        Match point layers to Overture Places and trace source records through bridge files
+                        Add GERS IDs to your point data by matching it to downloaded Overture Places, or trace existing GERS IDs back to source records with bridge files
 						<disabledText>Unable to open GERSify Data at this time</disabledText></tooltip>
 				</button>
 				<button id="DuckDBGeoparquet_Views_MfcDockpane_ShowButton" caption="Create MFC" className="DuckDBGeoparquet.Views.MfcDockpane_ShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="C" extendedCaption="Create Multifile Feature Connection">

--- a/Config.daml
+++ b/Config.daml
@@ -57,16 +57,16 @@
 				</tool>
 			</controls>
 			<dockPanes>
-				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane_V2" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.WizardDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane_V2" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane_V2" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.GersifyDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane_V2" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.MfcDockpaneView" />
 				</dockPane>
 			</dockPanes>

--- a/Config.daml
+++ b/Config.daml
@@ -23,6 +23,7 @@
 					<labelControl refID="DuckDBGeoparquet_OvertureMapDescription" />
 					<button refID="DuckDBGeoparquet_Views_WizardDockpane_ShowButton" size="large" />
 					<button refID="DuckDBGeoparquet_Views_OvertureGeocoderDockpane_ShowButton" size="large" />
+					<button refID="DuckDBGeoparquet_Views_GersifyDockpane_ShowButton" size="large" />
 					<button refID="DuckDBGeoparquet_Views_MfcDockpane_ShowButton" size="large" />
 				</group>
 			</groups>
@@ -37,6 +38,11 @@
 					<tooltip heading="Overture Geocoder">
                         Search loaded Overture address and place data
 						<disabledText>Unable to open Overture Geocoder at this time</disabledText></tooltip>
+				</button>
+				<button id="DuckDBGeoparquet_Views_GersifyDockpane_ShowButton" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="F" extendedCaption="Match User Data to Overture GERS IDs">
+					<tooltip heading="GERSify Data">
+                        Match point layers to Overture Places and trace source records through bridge files
+						<disabledText>Unable to open GERSify Data at this time</disabledText></tooltip>
 				</button>
 				<button id="DuckDBGeoparquet_Views_MfcDockpane_ShowButton" caption="Create MFC" className="DuckDBGeoparquet.Views.MfcDockpane_ShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="C" extendedCaption="Create Multifile Feature Connection">
 					<tooltip heading="Create MFC">
@@ -56,6 +62,9 @@
 				</dockPane>
 				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
 					<content className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneView" />
+				</dockPane>
+				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
+					<content className="DuckDBGeoparquet.Views.GersifyDockpaneView" />
 				</dockPane>
 				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
 					<content className="DuckDBGeoparquet.Views.MfcDockpaneView" />

--- a/Config.daml
+++ b/Config.daml
@@ -57,16 +57,16 @@
 				</tool>
 			</controls>
 			<dockPanes>
-				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.WizardDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.GersifyDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="right" dockWith="esri_core_contentsDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.MfcDockpaneView" />
 				</dockPane>
 			</dockPanes>

--- a/Config.daml
+++ b/Config.daml
@@ -41,7 +41,7 @@
 				</button>
 				<button id="DuckDBGeoparquet_Views_GersifyDockpane_ShowButton" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="F" extendedCaption="Match User Data to Overture GERS IDs">
 					<tooltip heading="GERSify Data">
-                        Add GERS IDs to your point data by matching it to downloaded Overture Places, or trace existing GERS IDs back to source records with bridge files
+                        Add GERS IDs to your point data by matching it to downloaded Overture Addresses or Places, or trace existing GERS IDs back to source records with bridge files
 						<disabledText>Unable to open GERSify Data at this time</disabledText></tooltip>
 				</button>
 				<button id="DuckDBGeoparquet_Views_MfcDockpane_ShowButton" caption="Create MFC" className="DuckDBGeoparquet.Views.MfcDockpane_ShowButton" loadOnClick="true" smallImage="Images\Overture16.png" largeImage="Images\Overture32.png" keytip="C" extendedCaption="Create Multifile Feature Connection">

--- a/Config.daml
+++ b/Config.daml
@@ -57,16 +57,16 @@
 				</tool>
 			</controls>
 			<dockPanes>
-				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane_V2" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane_V2" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="right">
 					<content className="DuckDBGeoparquet.Views.WizardDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane_V2" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane_V2" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="group" dockWith="DuckDBGeoparquet_Views_WizardDockpane_V2">
 					<content className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane_V2" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane_V2" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="group" dockWith="DuckDBGeoparquet_Views_WizardDockpane_V2">
 					<content className="DuckDBGeoparquet.Views.GersifyDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane_V2" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane_V2" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="group" dockWith="DuckDBGeoparquet_Views_WizardDockpane_V2">
 					<content className="DuckDBGeoparquet.Views.MfcDockpaneView" />
 				</dockPane>
 			</dockPanes>

--- a/Config.daml
+++ b/Config.daml
@@ -57,16 +57,16 @@
 				</tool>
 			</controls>
 			<dockPanes>
-				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_WizardDockpane" caption="Overture Maps Data Loader" className="DuckDBGeoparquet.Views.WizardDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.WizardDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_OvertureGeocoderDockpane" caption="Overture Geocoder" className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.OvertureGeocoderDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_GersifyDockpane" caption="GERSify Data" className="DuckDBGeoparquet.Views.GersifyDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.GersifyDockpaneView" />
 				</dockPane>
-				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="right" dockWith="esri_core_projectDockPane">
+				<dockPane id="DuckDBGeoparquet_Views_MfcDockpane" caption="Create Overture MFC" className="DuckDBGeoparquet.Views.MfcDockpaneViewModel" dock="group" dockWith="esri_core_projectDockPane">
 					<content className="DuckDBGeoparquet.Views.MfcDockpaneView" />
 				</dockPane>
 			</dockPanes>

--- a/DuckDBGeoparquet.Tests/ArcGisNameSanitizerTests.cs
+++ b/DuckDBGeoparquet.Tests/ArcGisNameSanitizerTests.cs
@@ -1,0 +1,32 @@
+using DuckDBGeoparquet.Services;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class ArcGisNameSanitizerTests
+    {
+        [Fact]
+        public void ToFileGeodatabaseFeatureClassName_ReplacesQualifiedDatabaseNamePunctuation()
+        {
+            string result = ArcGisNameSanitizer.ToFileGeodatabaseFeatureClassName("GERSified_geoprod.CY_FRESNO.ADDRESS_VW");
+
+            Assert.Equal("GERSified_geoprod_CY_FRESNO_ADDRESS_VW", result);
+        }
+
+        [Fact]
+        public void ToFileGeodatabaseFeatureClassName_PrefixesNamesThatDoNotStartWithLetter()
+        {
+            string result = ArcGisNameSanitizer.ToFileGeodatabaseFeatureClassName("123 bad/name");
+
+            Assert.Equal("fc_123_bad_name", result);
+        }
+
+        [Fact]
+        public void ToFileGeodatabaseFeatureClassName_FallsBackWhenInputIsEmpty()
+        {
+            string result = ArcGisNameSanitizer.ToFileGeodatabaseFeatureClassName("...", "FallbackName");
+
+            Assert.Equal("FallbackName", result);
+        }
+    }
+}

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -10,10 +10,12 @@
 		     installed. Anything linked here must stay free of ArcGIS types. -->
 		<Compile Include="..\Models\GeocodeCandidate.cs" Link="Linked\GeocodeCandidate.cs" />
 		<Compile Include="..\Models\ExtentBounds.cs" Link="Linked\ExtentBounds.cs" />
+		<Compile Include="..\Models\GersifyOptions.cs" Link="Linked\GersifyOptions.cs" />
 		<Compile Include="..\Models\OvertureSchema.cs" Link="Linked\OvertureSchema.cs" />
 		<Compile Include="..\Services\GeocodeResultLabels.cs" Link="Linked\GeocodeResultLabels.cs" />
 		<Compile Include="..\Services\GeocodeFileQueryBuilder.cs" Link="Linked\GeocodeFileQueryBuilder.cs" />
 		<Compile Include="..\Services\GeocodeTextNormalizer.cs" Link="Linked\GeocodeTextNormalizer.cs" />
+		<Compile Include="..\Services\GersSql.cs" Link="Linked\GersSql.cs" />
 		<Compile Include="..\Services\GeoParquetSql.cs" Link="Linked\GeoParquetSql.cs" />
 		<Compile Include="..\Services\S3Ingester.cs" Link="Linked\S3Ingester.cs" />
 		<Compile Include="..\Services\ParquetFileDeleter.cs" Link="Linked\ParquetFileDeleter.cs" />

--- a/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
+++ b/DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj
@@ -13,6 +13,7 @@
 		<Compile Include="..\Models\GersifyOptions.cs" Link="Linked\GersifyOptions.cs" />
 		<Compile Include="..\Models\OvertureSchema.cs" Link="Linked\OvertureSchema.cs" />
 		<Compile Include="..\Services\GeocodeResultLabels.cs" Link="Linked\GeocodeResultLabels.cs" />
+		<Compile Include="..\Services\ArcGisNameSanitizer.cs" Link="Linked\ArcGisNameSanitizer.cs" />
 		<Compile Include="..\Services\GeocodeFileQueryBuilder.cs" Link="Linked\GeocodeFileQueryBuilder.cs" />
 		<Compile Include="..\Services\GeocodeTextNormalizer.cs" Link="Linked\GeocodeTextNormalizer.cs" />
 		<Compile Include="..\Services\GersSql.cs" Link="Linked\GersSql.cs" />

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -32,6 +32,29 @@ namespace DuckDBGeoparquet.Tests
         }
 
         [Fact]
+        public void BuildPlacesCandidateTablesCommand_AllowsAddressOnlyCandidateLane()
+        {
+            var options = new GersifyOptions
+            {
+                MaxDistanceMeters = 75,
+                NameSimilarityThreshold = 0.86,
+                AddressSimilarityThreshold = 0.72,
+                AcceptScoreThreshold = 72
+            };
+
+            string sql = GersSql.BuildPlacesCandidateTablesCommand(
+                "/data/release/place/*.parquet",
+                options,
+                ["id", "name", "address_freeform", "geometry"]);
+
+            Assert.Contains("CAST(address_freeform AS VARCHAR)", sql);
+            Assert.Contains("OR (u.user_address_norm <> '' AND o.overture_address_norm <> '')", sql);
+            Assert.Contains("WHEN user_name_norm = '' OR overture_name_norm = '' THEN NULL", sql);
+            Assert.Contains("WHEN name_similarity IS NULL THEN (address_similarity * 80.0) + (distance_similarity * 20.0)", sql);
+            Assert.Contains("AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)", sql);
+        }
+
+        [Fact]
         public void BuildPlacesCandidateTablesCommand_SkipsBboxFilterWhenBboxColumnMissing()
         {
             var options = new GersifyOptions

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -28,7 +28,7 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("bbox.xmin <= -119", sql);
             Assert.DoesNotContain("addresses[1].freeform", sql);
             Assert.Contains("jaro_winkler_similarity", sql);
-            Assert.Contains("o.overture_name_norm,\n                        o.overture_address_norm,", sql);
+            Assert.Contains("o.overture_name_norm,\n                        o.overture_street_norm,", sql);
         }
 
         [Fact]
@@ -48,10 +48,31 @@ namespace DuckDBGeoparquet.Tests
                 ["id", "name", "address_freeform", "geometry"]);
 
             Assert.Contains("CAST(address_freeform AS VARCHAR)", sql);
-            Assert.Contains("OR (u.user_address_norm <> '' AND o.overture_address_norm <> '')", sql);
+            Assert.Contains("OR (u.user_street_norm <> '' AND o.overture_street_norm <> '')", sql);
+            Assert.Contains("OR (u.user_name_norm = '' AND u.user_street_norm <> '' AND o.overture_name_norm <> '')", sql);
             Assert.Contains("WHEN user_name_norm = '' OR overture_name_norm = '' THEN NULL", sql);
+            Assert.Contains("jaro_winkler_similarity(user_street_norm, overture_street_norm)", sql);
             Assert.Contains("WHEN name_similarity IS NULL THEN (address_similarity * 80.0) + (distance_similarity * 20.0)", sql);
             Assert.Contains("AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)", sql);
+            Assert.Contains("AND distance_m <= 15", sql);
+            Assert.Contains("ELSE 'nearby_only'", sql);
+            Assert.Contains("a.match_strategy AS gers_match_strategy", sql);
+        }
+
+        [Fact]
+        public void BuildPlacesCandidateTablesCommand_UsesOvertureAddressContextWhenAvailable()
+        {
+            var options = new GersifyOptions();
+
+            string sql = GersSql.BuildPlacesCandidateTablesCommand(
+                "/data/release/place/*.parquet",
+                options,
+                ["id", "names", "addresses", "geometry"]);
+
+            Assert.Contains("CAST(addresses[1].freeform AS VARCHAR)", sql);
+            Assert.Contains("CAST(addresses[1].locality AS VARCHAR)", sql);
+            Assert.Contains("CAST(addresses[1].region AS VARCHAR)", sql);
+            Assert.Contains("left(CAST(addresses[1].postcode AS VARCHAR), 5)", sql);
         }
 
         [Fact]

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -62,6 +62,50 @@ namespace DuckDBGeoparquet.Tests
         }
 
         [Fact]
+        public void BuildPlacesCandidateTablesCommand_CanDisableNearbyOnlyAcceptance()
+        {
+            var options = new GersifyOptions
+            {
+                MaxDistanceMeters = 75,
+                AllowNearbyOnlyMatches = false
+            };
+
+            string sql = GersSql.BuildPlacesCandidateTablesCommand(
+                "/data/release/place/*.parquet",
+                options,
+                ["id", "name", "address_freeform", "geometry"]);
+
+            Assert.DoesNotContain("AND distance_m <= 15", sql);
+            Assert.Contains("AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)", sql);
+        }
+
+        [Fact]
+        public void BuildAddressesCandidateTablesCommand_UsesStrictAddressSignals()
+        {
+            var options = new GersifyOptions
+            {
+                TargetType = GersifyTargetType.Addresses,
+                MaxDistanceMeters = 75,
+                AddressSimilarityThreshold = 0.72,
+                AcceptScoreThreshold = 72
+            };
+
+            string sql = GersSql.BuildAddressesCandidateTablesCommand(
+                "/data/release/address/*.parquet",
+                options,
+                ["id", "number", "street", "unit", "postal_city", "region", "postcode", "country", "geometry", "bbox"]);
+
+            Assert.Contains("read_parquet('/data/release/address/*.parquet', hive_partitioning=1, union_by_name=1)", sql);
+            Assert.Contains("CAST(number AS VARCHAR)", sql);
+            Assert.Contains("CAST(street AS VARCHAR)", sql);
+            Assert.Contains("AS house_number_match", sql);
+            Assert.Contains("AS postcode_compatible", sql);
+            Assert.Contains("WHEN house_number_match AND postcode_compatible AND address_similarity >= 0.96 THEN 'exact_address'", sql);
+            Assert.Contains("AND house_number_match", sql);
+            Assert.Contains("a.overture_address", sql);
+        }
+
+        [Fact]
         public void BuildPlacesCandidateTablesCommand_UsesOvertureAddressContextWhenAvailable()
         {
             var options = new GersifyOptions();
@@ -104,6 +148,15 @@ namespace DuckDBGeoparquet.Tests
         }
 
         [Fact]
+        public void HasAddressDatasetColumns_RequiresNumberAndStreet()
+        {
+            Assert.True(GersSql.HasAddressDatasetColumns(["id", "number", "street", "geometry"]));
+            Assert.True(GersSql.HasAddressDatasetColumns(["id", "house_number", "road", "geometry"]));
+            Assert.False(GersSql.HasAddressDatasetColumns(["id", "number", "postcode", "geometry"]));
+            Assert.False(GersSql.HasAddressDatasetColumns(["id", "street", "postcode", "geometry"]));
+        }
+
+        [Fact]
         public void BuildPlacesCandidateTablesCommand_SkipsBboxFilterWhenBboxColumnMissing()
         {
             var options = new GersifyOptions
@@ -118,6 +171,22 @@ namespace DuckDBGeoparquet.Tests
 
             Assert.Contains("CAST(name AS VARCHAR)", sql);
             Assert.DoesNotContain("bbox.xmin", sql);
+        }
+
+        [Fact]
+        public void BuildCopyGersifyOutputsCommand_WritesSelectedTargetToBridgeCsv()
+        {
+            string sql = GersSql.BuildCopyGersifyOutputsCommand(
+                "/tmp/output.csv",
+                "/tmp/candidates.csv",
+                "/tmp/bridge.csv",
+                "fresno_addresses",
+                "addresses",
+                "address");
+
+            Assert.Contains("'fresno_addresses' AS dataset", sql);
+            Assert.Contains("'addresses' AS theme", sql);
+            Assert.Contains("'address' AS type", sql);
         }
 
         [Fact]

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -28,6 +28,7 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("bbox.xmin <= -119", sql);
             Assert.DoesNotContain("addresses[1].freeform", sql);
             Assert.Contains("jaro_winkler_similarity", sql);
+            Assert.Contains("o.overture_name_norm,\n                        o.overture_address_norm,", sql);
         }
 
         [Fact]

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -1,0 +1,73 @@
+using DuckDBGeoparquet.Models;
+using DuckDBGeoparquet.Services;
+using Xunit;
+
+namespace DuckDBGeoparquet.Tests
+{
+    public class GersSqlTests
+    {
+        [Fact]
+        public void BuildPlacesCandidateTablesCommand_UsesSchemaAwarePlaceExpressions()
+        {
+            var options = new GersifyOptions
+            {
+                InputExtent = new ExtentBounds(-120, 36, -119, 37),
+                MaxDistanceMeters = 100,
+                NameSimilarityThreshold = 0.8,
+                AddressSimilarityThreshold = 0.7,
+                AcceptScoreThreshold = 70
+            };
+
+            string sql = GersSql.BuildPlacesCandidateTablesCommand(
+                "/data/release/place/*.parquet",
+                options,
+                ["id", "names", "geometry", "bbox"]);
+
+            Assert.Contains("CAST(names.primary AS VARCHAR)", sql);
+            Assert.Contains("coalesce('', '') AS overture_address", sql);
+            Assert.Contains("bbox.xmin <= -119", sql);
+            Assert.DoesNotContain("addresses[1].freeform", sql);
+            Assert.Contains("jaro_winkler_similarity", sql);
+        }
+
+        [Fact]
+        public void BuildPlacesCandidateTablesCommand_SkipsBboxFilterWhenBboxColumnMissing()
+        {
+            var options = new GersifyOptions
+            {
+                InputExtent = new ExtentBounds(-120, 36, -119, 37)
+            };
+
+            string sql = GersSql.BuildPlacesCandidateTablesCommand(
+                "/data/release/place/*.parquet",
+                options,
+                ["id", "name", "geometry"]);
+
+            Assert.Contains("CAST(name AS VARCHAR)", sql);
+            Assert.DoesNotContain("bbox.xmin", sql);
+        }
+
+        [Fact]
+        public void BuildTraceSourcesCommand_BuildsBridgeGlobAndOsmUrl()
+        {
+            var options = new TraceSourcesOptions
+            {
+                BridgeRoot = "s3://overturemaps-us-west-2/bridgefiles",
+                Release = "2026-06-17.0",
+                Theme = "places",
+                Type = "place",
+                InputCsvPath = "/tmp/input.csv",
+                OutputFolder = "/tmp"
+            };
+
+            string glob = GersSql.BuildBridgeGlob(options.BridgeRoot, options.Release);
+            string sql = GersSql.BuildTraceSourcesCommand(options, "/tmp/output.csv");
+
+            Assert.Equal("s3://overturemaps-us-west-2/bridgefiles/2026-06-17.0/**/*.parquet", glob);
+            Assert.Contains("theme = 'places'", sql);
+            Assert.Contains("type = 'place'", sql);
+            Assert.Contains("BuildOsmUrl", sql);
+            Assert.Contains("/tmp/output.csv", sql);
+        }
+    }
+}

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -29,7 +29,8 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("read_parquet('/data/release/place/*.parquet', hive_partitioning=1, union_by_name=1)", sql);
             Assert.DoesNotContain("unnest(addresses)", sql);
             Assert.Contains("jaro_winkler_similarity", sql);
-            Assert.Contains("o.overture_name_norm,\n                        o.overture_street_norm,", sql);
+            string normalizedSql = sql.Replace("\r\n", "\n", System.StringComparison.Ordinal);
+            Assert.Contains("o.overture_name_norm,\n                        o.overture_street_norm,", normalizedSql);
         }
 
         [Fact]

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -26,6 +26,7 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("CAST(names.primary AS VARCHAR)", sql);
             Assert.Contains("coalesce('', '') AS overture_address", sql);
             Assert.Contains("bbox.xmin <= -119", sql);
+            Assert.Contains("read_parquet('/data/release/place/*.parquet', hive_partitioning=1, union_by_name=1)", sql);
             Assert.DoesNotContain("unnest(addresses)", sql);
             Assert.Contains("jaro_winkler_similarity", sql);
             Assert.Contains("o.overture_name_norm,\n                        o.overture_street_norm,", sql);
@@ -91,6 +92,15 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("CAST(address_region AS VARCHAR)", sql);
             Assert.Contains("left(CAST(address_postcode AS VARCHAR), 5)", sql);
             Assert.DoesNotContain("unnest(addresses)", sql);
+        }
+
+        [Fact]
+        public void HasPlaceAddressColumns_DetectsNestedAndFlattenedAddressInputs()
+        {
+            Assert.True(GersSql.HasPlaceAddressColumns(["id", "names", "addresses", "geometry"]));
+            Assert.True(GersSql.HasPlaceAddressColumns(["id", "names", "address_freeform", "geometry"]));
+            Assert.True(GersSql.HasPlaceAddressColumns(["id", "names", "full_address", "geometry"]));
+            Assert.False(GersSql.HasPlaceAddressColumns(["id", "names", "geometry", "bbox"]));
         }
 
         [Fact]

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -100,7 +100,7 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("CAST(street AS VARCHAR)", sql);
             Assert.Contains("AS house_number_match", sql);
             Assert.Contains("AS postcode_compatible", sql);
-            Assert.Contains("WHEN house_number_match AND postcode_compatible AND address_similarity >= 0.96 THEN 'exact_address'", sql);
+            Assert.Contains("WHEN house_number_match AND postcode_compatible AND address_similarity >= 0.995 THEN 'exact_address'", sql);
             Assert.Contains("AND house_number_match", sql);
             Assert.Contains("a.overture_address", sql);
         }

--- a/DuckDBGeoparquet.Tests/GersSqlTests.cs
+++ b/DuckDBGeoparquet.Tests/GersSqlTests.cs
@@ -26,7 +26,7 @@ namespace DuckDBGeoparquet.Tests
             Assert.Contains("CAST(names.primary AS VARCHAR)", sql);
             Assert.Contains("coalesce('', '') AS overture_address", sql);
             Assert.Contains("bbox.xmin <= -119", sql);
-            Assert.DoesNotContain("addresses[1].freeform", sql);
+            Assert.DoesNotContain("unnest(addresses)", sql);
             Assert.Contains("jaro_winkler_similarity", sql);
             Assert.Contains("o.overture_name_norm,\n                        o.overture_street_norm,", sql);
         }
@@ -48,6 +48,7 @@ namespace DuckDBGeoparquet.Tests
                 ["id", "name", "address_freeform", "geometry"]);
 
             Assert.Contains("CAST(address_freeform AS VARCHAR)", sql);
+            Assert.DoesNotContain("unnest(addresses)", sql);
             Assert.Contains("OR (u.user_street_norm <> '' AND o.overture_street_norm <> '')", sql);
             Assert.Contains("OR (u.user_name_norm = '' AND u.user_street_norm <> '' AND o.overture_name_norm <> '')", sql);
             Assert.Contains("WHEN user_name_norm = '' OR overture_name_norm = '' THEN NULL", sql);
@@ -69,10 +70,27 @@ namespace DuckDBGeoparquet.Tests
                 options,
                 ["id", "names", "addresses", "geometry"]);
 
-            Assert.Contains("CAST(addresses[1].freeform AS VARCHAR)", sql);
-            Assert.Contains("CAST(addresses[1].locality AS VARCHAR)", sql);
-            Assert.Contains("CAST(addresses[1].region AS VARCHAR)", sql);
-            Assert.Contains("left(CAST(addresses[1].postcode AS VARCHAR), 5)", sql);
+            Assert.Contains("string_agg(CAST(a.freeform AS VARCHAR), ' | ')", sql);
+            Assert.Contains("string_agg(DISTINCT CAST(a.locality AS VARCHAR), ' | ')", sql);
+            Assert.Contains("string_agg(DISTINCT CAST(a.region AS VARCHAR), ' | ')", sql);
+            Assert.Contains("string_agg(DISTINCT left(CAST(a.postcode AS VARCHAR), 5), ' | ')", sql);
+        }
+
+        [Fact]
+        public void BuildPlacesCandidateTablesCommand_UsesFlattenedOvertureAddressContextWhenAvailable()
+        {
+            var options = new GersifyOptions();
+
+            string sql = GersSql.BuildPlacesCandidateTablesCommand(
+                "/data/release/place/*.parquet",
+                options,
+                ["id", "names", "address_freeform", "address_locality", "address_region", "address_postcode", "geometry"]);
+
+            Assert.Contains("CAST(address_freeform AS VARCHAR)", sql);
+            Assert.Contains("CAST(address_locality AS VARCHAR)", sql);
+            Assert.Contains("CAST(address_region AS VARCHAR)", sql);
+            Assert.Contains("left(CAST(address_postcode AS VARCHAR), 5)", sql);
+            Assert.DoesNotContain("unnest(addresses)", sql);
         }
 
         [Fact]

--- a/DuckDBGeoparquet.Tests/S3IngesterTests.cs
+++ b/DuckDBGeoparquet.Tests/S3IngesterTests.cs
@@ -70,7 +70,7 @@ namespace DuckDBGeoparquet.Tests
 
             Assert.Contains("CREATE OR REPLACE TABLE current_table", query);
             Assert.Contains("SELECT *", query);
-            Assert.Contains("read_parquet('s3://bucket/*.parquet', filename=true, hive_partitioning=1)", query);
+            Assert.Contains("read_parquet('s3://bucket/*.parquet', filename=true, hive_partitioning=1, union_by_name=1)", query);
             // No extent → no spatial filter and no clipping.
             Assert.DoesNotContain("WHERE", query);
             Assert.DoesNotContain("ST_Intersection", query);

--- a/DuckDBGeoparquet.Tests/S3IngesterTests.cs
+++ b/DuckDBGeoparquet.Tests/S3IngesterTests.cs
@@ -87,6 +87,16 @@ namespace DuckDBGeoparquet.Tests
         }
 
         [Fact]
+        public void BuildLoadQuery_ForPlaces_FlattensAddressFreeformWhenAddressesArePresent()
+        {
+            var columns = new List<string> { "id", "names", "addresses", "geometry", "bbox", "sources" };
+            string query = S3Ingester.BuildLoadQuery("s3://bucket/place/*", "place", columns, extent: null);
+
+            Assert.Contains("CAST(addresses[1].freeform AS VARCHAR) AS address_freeform", query);
+            Assert.DoesNotContain("SELECT id, names, addresses", query);
+        }
+
+        [Fact]
         public void BuildLoadQuery_WithExtentAndBbox_ClipsAndRepacksBbox()
         {
             var extent = new ExtentBounds(1, 2, 3, 4);

--- a/DuckDBGeoparquet.Tests/S3IngesterTests.cs
+++ b/DuckDBGeoparquet.Tests/S3IngesterTests.cs
@@ -87,13 +87,28 @@ namespace DuckDBGeoparquet.Tests
         }
 
         [Fact]
-        public void BuildLoadQuery_ForPlaces_FlattensAddressFreeformWhenAddressesArePresent()
+        public void BuildLoadQuery_ForPlaces_FlattensAddressFieldsWhenAddressesArePresent()
         {
             var columns = new List<string> { "id", "names", "addresses", "geometry", "bbox", "sources" };
             string query = S3Ingester.BuildLoadQuery("s3://bucket/place/*", "place", columns, extent: null);
 
-            Assert.Contains("CAST(addresses[1].freeform AS VARCHAR) AS address_freeform", query);
+            Assert.Contains("string_agg(CAST(a.freeform AS VARCHAR), ' | ')", query);
+            Assert.Contains("AS address_freeform", query);
+            Assert.Contains("AS address_locality", query);
+            Assert.Contains("AS address_region", query);
+            Assert.Contains("AS address_postcode", query);
+            Assert.Contains("AS address_country", query);
             Assert.DoesNotContain("SELECT id, names, addresses", query);
+        }
+
+        [Fact]
+        public void BuildLoadQuery_ForPlaces_DoesNotDuplicateExistingFlattenedAddressFields()
+        {
+            var columns = new List<string> { "id", "names", "addresses", "address_freeform", "geometry", "bbox" };
+            string query = S3Ingester.BuildLoadQuery("s3://bucket/place/*", "place", columns, extent: null);
+
+            Assert.DoesNotContain("AS address_freeform", query);
+            Assert.Contains("AS address_locality", query);
         }
 
         [Fact]

--- a/Models/GersMatchCandidate.cs
+++ b/Models/GersMatchCandidate.cs
@@ -1,0 +1,20 @@
+namespace DuckDBGeoparquet.Models
+{
+    public class GersMatchCandidate
+    {
+        public string RecordId { get; set; }
+        public string UserName { get; set; }
+        public string UserAddress { get; set; }
+        public double Longitude { get; set; }
+        public double Latitude { get; set; }
+        public string GersId { get; set; }
+        public string OvertureId { get; set; }
+        public string OvertureName { get; set; }
+        public double DistanceMeters { get; set; }
+        public double NameSimilarity { get; set; }
+        public double? AddressSimilarity { get; set; }
+        public double MatchScore { get; set; }
+        public int CandidateRank { get; set; }
+        public bool Accepted { get; set; }
+    }
+}

--- a/Models/GersifyOptions.cs
+++ b/Models/GersifyOptions.cs
@@ -2,8 +2,15 @@ using System;
 
 namespace DuckDBGeoparquet.Models
 {
+    public enum GersifyTargetType
+    {
+        Places,
+        Addresses
+    }
+
     public class GersifyOptions
     {
+        public GersifyTargetType TargetType { get; set; } = GersifyTargetType.Places;
         public string InputCsvPath { get; set; }
         public string InputLayerName { get; set; }
         public string UniqueIdField { get; set; }
@@ -28,6 +35,11 @@ namespace DuckDBGeoparquet.Models
         public double AddressSimilarityThreshold { get; set; } = 0.72;
         public double AcceptScoreThreshold { get; set; } = 72;
         public int ReviewCandidatesPerRecord { get; set; } = 5;
+        public bool AllowNearbyOnlyMatches { get; set; } = true;
+
+        public string TargetTheme => TargetType == GersifyTargetType.Addresses ? "addresses" : "places";
+        public string TargetDatasetType => TargetType == GersifyTargetType.Addresses ? "address" : "place";
+        public string TargetLabel => TargetType == GersifyTargetType.Addresses ? "Overture Addresses" : "Overture Places";
 
         public static string DefaultReleaseVersion => "2026-06-17.0";
 

--- a/Models/GersifyOptions.cs
+++ b/Models/GersifyOptions.cs
@@ -9,6 +9,13 @@ namespace DuckDBGeoparquet.Models
         public string UniqueIdField { get; set; }
         public string NameField { get; set; }
         public string AddressField { get; set; }
+        public string StreetNumberField { get; set; }
+        public string StreetFractionField { get; set; }
+        public string StreetPrefixField { get; set; }
+        public string StreetNameField { get; set; }
+        public string StreetTypeField { get; set; }
+        public string StreetSuffixField { get; set; }
+        public string UnitField { get; set; }
         public string CityField { get; set; }
         public string StateField { get; set; }
         public string PostcodeField { get; set; }

--- a/Models/GersifyOptions.cs
+++ b/Models/GersifyOptions.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace DuckDBGeoparquet.Models
+{
+    public class GersifyOptions
+    {
+        public string InputCsvPath { get; set; }
+        public string InputLayerName { get; set; }
+        public string UniqueIdField { get; set; }
+        public string NameField { get; set; }
+        public string AddressField { get; set; }
+        public string CityField { get; set; }
+        public string StateField { get; set; }
+        public string PostcodeField { get; set; }
+        public string OvertureReleaseFolder { get; set; }
+        public string OutputFolder { get; set; }
+        public string DatasetName { get; set; } = "user_data";
+        public ExtentBounds InputExtent { get; set; }
+        public double MaxDistanceMeters { get; set; } = 75;
+        public double NameSimilarityThreshold { get; set; } = 0.86;
+        public double AddressSimilarityThreshold { get; set; } = 0.72;
+        public double AcceptScoreThreshold { get; set; } = 72;
+        public int ReviewCandidatesPerRecord { get; set; } = 5;
+
+        public static string DefaultReleaseVersion => "2026-06-17.0";
+
+        public static string BuildTimestampSuffix() =>
+            DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    public class TraceSourcesOptions
+    {
+        public string InputCsvPath { get; set; }
+        public string OutputFolder { get; set; }
+        public string BridgeRoot { get; set; } = "https://overturemapswestus2.blob.core.windows.net/bridgefiles";
+        public string Release { get; set; } = GersifyOptions.DefaultReleaseVersion;
+        public string Theme { get; set; } = "places";
+        public string Type { get; set; } = "place";
+        public int MaxRows { get; set; } = 250000;
+    }
+}

--- a/Models/GersifyResult.cs
+++ b/Models/GersifyResult.cs
@@ -8,6 +8,8 @@ namespace DuckDBGeoparquet.Models
         public int InputNameCount { get; set; }
         public int InputAddressCount { get; set; }
         public int CandidateCount { get; set; }
+        public int CandidateOvertureAddressCount { get; set; }
+        public int CandidateAddressSimilarityCount { get; set; }
         public int AcceptedCount { get; set; }
         public string OutputCsvPath { get; set; }
         public string CandidateCsvPath { get; set; }

--- a/Models/GersifyResult.cs
+++ b/Models/GersifyResult.cs
@@ -4,6 +4,9 @@ namespace DuckDBGeoparquet.Models
 {
     public class GersifyResult
     {
+        public string TargetLabel { get; set; }
+        public string TargetTheme { get; set; }
+        public string TargetDatasetType { get; set; }
         public int InputCount { get; set; }
         public int InputNameCount { get; set; }
         public int InputAddressCount { get; set; }
@@ -15,6 +18,7 @@ namespace DuckDBGeoparquet.Models
         public string CandidateCsvPath { get; set; }
         public string BridgeCsvPath { get; set; }
         public string OutputFeatureClassPath { get; set; }
+        public IReadOnlyDictionary<string, int> AcceptedStrategyCounts { get; set; } = new Dictionary<string, int>();
         public IReadOnlyList<GersMatchCandidate> AcceptedMatches { get; set; } = [];
     }
 

--- a/Models/GersifyResult.cs
+++ b/Models/GersifyResult.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace DuckDBGeoparquet.Models
+{
+    public class GersifyResult
+    {
+        public int InputCount { get; set; }
+        public int CandidateCount { get; set; }
+        public int AcceptedCount { get; set; }
+        public string OutputCsvPath { get; set; }
+        public string CandidateCsvPath { get; set; }
+        public string BridgeCsvPath { get; set; }
+        public string OutputFeatureClassPath { get; set; }
+        public IReadOnlyList<GersMatchCandidate> AcceptedMatches { get; set; } = [];
+    }
+
+    public class TraceSourcesResult
+    {
+        public int InputCount { get; set; }
+        public int OutputCount { get; set; }
+        public string OutputCsvPath { get; set; }
+    }
+}

--- a/Models/GersifyResult.cs
+++ b/Models/GersifyResult.cs
@@ -5,6 +5,8 @@ namespace DuckDBGeoparquet.Models
     public class GersifyResult
     {
         public int InputCount { get; set; }
+        public int InputNameCount { get; set; }
+        public int InputAddressCount { get; set; }
         public int CandidateCount { get; set; }
         public int AcceptedCount { get; set; }
         public string OutputCsvPath { get; set; }

--- a/SESSION_HANDOFF_2026-07-06_GERSIFY.md
+++ b/SESSION_HANDOFF_2026-07-06_GERSIFY.md
@@ -5,15 +5,19 @@ Use this as the starting brief for the next Codex session.
 ## Copy/Paste Prompt
 
 ```text
-Continue work in /Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin on branch codex/gersify-esri-tool.
+Continue work in the ArcGISPro-GeoParquet-Addin repo on branch codex/gersify-esri-tool.
 
-Read SESSION_HANDOFF_2026-07-06_GERSIFY.md first, then continue from there.
+I am on my Windows work machine, so do not assume the Mac path /Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin exists. Use the local Windows clone path for this repo, such as C:\Users\rylopez\source\repos\ArcGISPro-GeoParquet-Addin, or discover the current repo root from the session.
+
+First, make sure the Windows clone has the latest codex/gersify-esri-tool branch from GitHub. This handoff file is committed in the repo root as SESSION_HANDOFF_2026-07-06_GERSIFY.md after pulling the branch.
+
+Read SESSION_HANDOFF_2026-07-06_GERSIFY.md first if it is available locally, then continue from there. If it is not available yet, use this prompt as the handoff context.
 
 Important context:
 - We are building the "GERSify Data" tooling in the ArcGIS Pro Overture add-in.
 - The immediate proof point is Fresno County address data, but do not hard-code the product around Fresno. The long-term goal is that any jurisdiction, with its own schema and naming conventions, can map local data to stable Overture GERS IDs.
 - This should become the aha moment for local governments and GIS vendors: local data can be connected to the broader Overture Maps ecosystem, traceable source records, repeatable cartography, cross-release stable IDs, and downstream workflows.
-- Current branch is pushed through commit 11f4260 Fallback to known ZIP fields.
+- Current branch is pushed at least through commit 7592165 Add GERSify session handoff.
 - Tests passed locally: dotnet test DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj --no-build -v minimal, 97/97 passing.
 - On macOS, the add-in project compiles DuckDBGeoparquet.dll but the final Esri packaging target fails with the known CodeTaskFactory/ConvertToRelativePath issue. Full add-in validation should happen on Windows with ArcGIS Pro.
 
@@ -37,10 +41,11 @@ Fresno County data is the current proving ground. The architecture should stay g
 
 ## Current Branch / Repo State
 
-- Repo: `/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin`
+- Repo: use the local clone path on the current machine. On the Mac session it was `/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin`; on Windows it may be something like `C:\Users\rylopez\source\repos\ArcGISPro-GeoParquet-Addin`.
 - Branch: `codex/gersify-esri-tool`
 - Working tree was clean at handoff time.
 - Latest pushed commits:
+  - `7592165` Add GERSify session handoff
   - `11f4260` Fallback to known ZIP fields
   - `e1e9242` Tighten address match labeling
   - `da90cd4` Map Fresno street direction fields

--- a/SESSION_HANDOFF_2026-07-06_GERSIFY.md
+++ b/SESSION_HANDOFF_2026-07-06_GERSIFY.md
@@ -1,0 +1,296 @@
+# Session Handoff - GERSify Data - 2026-07-06
+
+Use this as the starting brief for the next Codex session.
+
+## Copy/Paste Prompt
+
+```text
+Continue work in /Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin on branch codex/gersify-esri-tool.
+
+Read SESSION_HANDOFF_2026-07-06_GERSIFY.md first, then continue from there.
+
+Important context:
+- We are building the "GERSify Data" tooling in the ArcGIS Pro Overture add-in.
+- The immediate proof point is Fresno County address data, but do not hard-code the product around Fresno. The long-term goal is that any jurisdiction, with its own schema and naming conventions, can map local data to stable Overture GERS IDs.
+- This should become the aha moment for local governments and GIS vendors: local data can be connected to the broader Overture Maps ecosystem, traceable source records, repeatable cartography, cross-release stable IDs, and downstream workflows.
+- Current branch is pushed through commit 11f4260 Fallback to known ZIP fields.
+- Tests passed locally: dotnet test DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj --no-build -v minimal, 97/97 passing.
+- On macOS, the add-in project compiles DuckDBGeoparquet.dll but the final Esri packaging target fails with the known CodeTaskFactory/ConvertToRelativePath issue. Full add-in validation should happen on Windows with ArcGIS Pro.
+
+Please verify the current state first, avoid redoing finished work, and focus on the remaining items listed in this handoff. Keep the tool jurisdiction-agnostic even while using Fresno data as the test fixture.
+```
+
+## Product North Star
+
+GERSify Data should let local governments and GIS vendors attach stable Overture GERS IDs to their own authoritative data, even when their schema does not look like Overture's schema.
+
+The tool should demonstrate that Overture is not just downloadable basemap data. It can become a connection layer:
+
+- Local records can be matched to stable GERS IDs.
+- GERS IDs can bridge local authoritative records to Overture themes.
+- Users can trace GERS IDs back to source datasets through bridge files.
+- Local data can benefit from Overture-aware cartography and enrichment.
+- Governments can compare their own data against the broader Overture ecosystem.
+- Vendors can build workflows around durable IDs instead of fragile names, addresses, or geometry-only joins.
+
+Fresno County data is the current proving ground. The architecture should stay generic enough for other counties, cities, states, utilities, MPOs, school districts, campus systems, and vendor schemas.
+
+## Current Branch / Repo State
+
+- Repo: `/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin`
+- Branch: `codex/gersify-esri-tool`
+- Working tree was clean at handoff time.
+- Latest pushed commits:
+  - `11f4260` Fallback to known ZIP fields
+  - `e1e9242` Tighten address match labeling
+  - `da90cd4` Map Fresno street direction fields
+  - `8b16875` Add address target to GERSify
+  - `0778706` Preserve place address fields for GERSify
+  - `9752321` Isolate add-in dock pane grouping
+
+## What Was Built
+
+### GERSify Data dockpane
+
+The GERSify dockpane now supports target selection instead of being Places-only.
+
+Current targets:
+
+- `Addresses`: strict address validation against Overture Addresses.
+- `Places`: POI/place enrichment against Overture Places.
+
+Important behavior:
+
+- `Addresses` is the default because the presentation/demo currently centers on validating authoritative Fresno address points.
+- `Allow nearby-only fallback` defaults off. This is intentional. The address validation story should not be based on proximity-only matches.
+- Places matching still supports nearby fallback when explicitly enabled.
+- Output layers are named with the target suffix, such as `..._address`.
+
+### Overture Addresses matching
+
+The address target uses Overture `addresses/address` GeoParquet files.
+
+Signals used:
+
+- House number equality.
+- Street/address similarity.
+- ZIP compatibility when ZIP is available.
+- Distance within the configured threshold.
+- Candidate ranking that prioritizes house-number and ZIP-compatible candidates.
+
+Strategy labels:
+
+- `exact_address`: near-literal address equality, currently `address_similarity >= 0.995`, with house number and ZIP compatibility.
+- `address`: accepted address match that is strong but not near-literal exact.
+- `nearby_only`: should not appear for strict address runs.
+
+The `exact_address` threshold was tightened because unit-suffixed local records, such as `5071 E BELMONT AVE A`, were matching a base Overture address and being overstated as exact. They should still be accepted where appropriate, but labeled more honestly as `address`.
+
+### Places address scoring
+
+Places matching was improved to preserve/use flattened and nested place address fields.
+
+Important fixes:
+
+- Overture Places downloads/read paths use `union_by_name=1`.
+- Places address fields are flattened when needed.
+- If an address-only input is matched against old Places files without usable address fields, the tool fails fast instead of silently producing nearby-only results.
+
+### Schema-specific Fresno fixes that should become generic behavior
+
+Fresno data exposed useful schema realities:
+
+- Parsed address fields may use names like `ADDRESS_NUMBER`, `STREET_DIRECTION`, `STREET_NAME`, `STREET_TYPE`, `STREET_POST_DIRECTION`, `ADDRESS_UNIT`, `ADDRESS_ZIPCITY`, `ADDRESS_ZIP5`.
+- Direction fields are essential. Without `N/E/S/W`, most true 1:1 matches were scoring as weaker `address` instead of `exact_address`.
+- The tool now auto-detects Fresno-style street direction fields.
+- A postcode guard now prevents non-numeric fields like `STREET_TYPE` from being exported as postcode. If the selected postcode value has no digits, the exporter falls back to known ZIP field names like `ADDRESS_ZIP5`, `ZIP5`, `POSTCODE`, `POSTAL_CODE`, and `ZIP`.
+
+This is a patch, not the final UX. The better long-term solution is a field-mapping preview/validator that shows exactly what the tool resolved before a user runs a 400k-row job.
+
+## Latest Fresno Run Evidence
+
+The latest reported full run used:
+
+- Input layer: `geoprod.REGIONAL_VIEWS.ADDRESS`
+- Input count: `398,762` point features
+- Input address coverage: `398,756` with addresses
+- Target: `Overture Addresses (addresses/address)`
+- Overture candidate address coverage: `1,501,127` with address text and similarity scores
+- Accepted matches: `298,638`
+- Accepted by strategy:
+  - `exact_address`: `277,026`
+  - `address`: `21,612`
+- Candidate review CSV: `gersify_candidates_20260706_014719.csv`
+- Bridge CSV: `gers_bridge_20260706_014719.csv`
+
+This is a strong demo result. It shows the value proposition:
+
+- A large authoritative government address layer can be connected to stable Overture GERS IDs.
+- Most accepted matches are true exact address matches after schema-aware field mapping.
+- The remaining `address` matches can be used for review or lower-confidence workflows.
+
+## Important Issues Found
+
+### 1. Postcode mapping can be wrong in the UI
+
+One sample output showed `postcode` values like `AVE`, `ST`, `RD`, and `DR`.
+
+The source table screenshot showed `ADDRESS_ZIP5` exists and contains proper ZIP values, so the output issue likely came from the Postcode combo box pointing at `STREET_TYPE`.
+
+Mitigation already pushed:
+
+- `11f4260` adds a fallback so non-numeric selected postcode values are replaced by known ZIP fields when possible.
+
+Recommended next step:
+
+- Add an explicit field-mapping preview/validation surface before running:
+  - Show selected Unique ID, Full Address, Number, Prefix, Street, Type, Suffix, Unit, City, State, Postcode.
+  - Show a small sample of built output strings.
+  - Warn when Postcode has no digits or looks like street type values.
+  - Warn when Street Direction exists in the source but is not selected.
+  - Warn when Address Unit exists and Overture lacks unit-level address candidates.
+
+### 2. Need better unmatched analysis
+
+The latest run matched `298,638` of `398,762`, leaving about `100k` unmatched.
+
+That may be normal depending on:
+
+- Input extent vs downloaded Overture extent.
+- Address points not included in current Overture release.
+- Unit-level/subaddress records not represented in Overture.
+- Non-site addresses, retired addresses, or records outside the selected data extract.
+- Threshold too strict for some rural or unusual addressing.
+
+Recommended next step:
+
+- Add an unmatched/review summary:
+  - No nearby candidates.
+  - House number mismatch.
+  - Street similarity below threshold.
+  - ZIP incompatible.
+  - Unit/subaddress only.
+  - Candidate outside distance threshold.
+
+This would make the tool much more compelling for government data stewardship because it turns "unmatched" into a work queue.
+
+## Remaining Product Work
+
+### Highest priority
+
+1. Verify the latest pushed commit on Windows/ArcGIS Pro:
+   - Pull `codex/gersify-esri-tool`.
+   - Rebuild add-in.
+   - Run the Fresno regional address layer again.
+   - Confirm output `postcode` contains real ZIP values, not street types.
+   - Confirm `exact_address` count remains high and unit-suffixed rows are labeled `address` when not truly exact.
+
+2. Add field mapping preview/validation:
+   - This is the biggest UX improvement for non-Fresno jurisdictions.
+   - Users need confidence that their schema was interpreted correctly before a long matching job.
+
+3. Add a match summary/report card:
+   - Accepted by strategy.
+   - Unmatched reason buckets.
+   - Candidate counts.
+   - Address/name coverage.
+   - Recommended next action.
+
+### Make it jurisdiction-agnostic
+
+Do not keep adding Fresno-only field names directly into workflow logic forever. Better direction:
+
+- Keep common aliases, but organize them into reusable schema profiles.
+- Add a scoring/ranking system for field auto-detection.
+- Let users save and reuse mappings per organization/dataset.
+- Detect suspicious mappings from sample values, not only field names.
+- Support both full-address fields and parsed-address fields.
+- Handle state/country/postcode variants across jurisdictions.
+- Keep a clear distinction between:
+  - Required fields.
+  - Useful context fields.
+  - Optional review/enrichment fields.
+
+### Expand beyond Addresses and Places
+
+The long-term goal is GERSification across Overture themes, not just address points.
+
+Potential targets:
+
+- `addresses/address`: authoritative address validation.
+- `places/place`: POI/facility enrichment.
+- `buildings/building`: local building footprints or facility/building inventories.
+- `divisions/*`: jurisdiction/administrative boundary linking.
+- `transportation/segment`: local centerlines, road assets, crash records, maintenance segments.
+- `base/land`, `base/water`, etc. may be less about record matching and more about cartographic/context workflows.
+
+Each theme probably needs its own matching strategy:
+
+- Addresses: number/street/ZIP/distance.
+- Places: name/address/category/distance.
+- Buildings: geometry overlap, centroid distance, parcel/address context.
+- Divisions: polygon overlap/name/admin level.
+- Transportation: geometry similarity, topology, road name, class, endpoints.
+
+The UI should expose "Match Target" while hiding theme-specific complexity unless needed.
+
+### Stable GERS ID workflows
+
+The aha moment should not stop at matching.
+
+Build toward workflows like:
+
+- Add GERS IDs to local data.
+- Trace GERS IDs back to Overture source records.
+- Re-run against a new Overture release and compare changed/missing/stable records.
+- Join local data to Overture attributes by GERS ID.
+- Apply Overture-aware cartography to GERSified local layers.
+- Create bridge CSV outputs that vendors/governments can use in ETL pipelines.
+- Export a review package for data stewards.
+
+Cartography idea from the user:
+
+- Once local data is GERSified, the add-in can quickly apply Overture-style symbology or theme-aware cartography.
+- This is a strong presentation point: instead of manually configuring many layers, a government user can use GERS IDs/theme metadata to enrich and style their data quickly.
+
+## Useful Files
+
+- [Config.daml](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Config.daml)
+- [Models/GersifyOptions.cs](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Models/GersifyOptions.cs)
+- [Models/GersifyResult.cs](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Models/GersifyResult.cs)
+- [Services/GersSql.cs](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Services/GersSql.cs)
+- [Services/GersifyService.cs](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Services/GersifyService.cs)
+- [Views/GersifyDockpane.xaml](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Views/GersifyDockpane.xaml)
+- [Views/GersifyDockpaneViewModel.cs](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/Views/GersifyDockpaneViewModel.cs)
+- [DuckDBGeoparquet.Tests/GersSqlTests.cs](/Users/ryanlopez/Desktop/ArcGISPro-GeoParquet-Addin/DuckDBGeoparquet.Tests/GersSqlTests.cs)
+
+## Verification Notes
+
+Commands that passed locally:
+
+```bash
+dotnet build DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj --no-restore -v minimal
+dotnet test DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj --no-build -v minimal
+```
+
+Test result:
+
+- `97/97` passing.
+
+Known macOS limitation:
+
+- `dotnet build DuckDBGeoparquet.csproj --no-restore -v minimal` compiles `DuckDBGeoparquet.dll`, then fails in Esri packaging with `CodeTaskFactory` / `ConvertToRelativePath`.
+- Treat this as expected on macOS; verify package/add-in behavior on Windows with ArcGIS Pro.
+
+## Suggested Next Move
+
+Start with a Windows validation run:
+
+1. Pull `codex/gersify-esri-tool`.
+2. Rebuild the add-in in Visual Studio.
+3. Run GERSify Data against `geoprod.REGIONAL_VIEWS.ADDRESS`.
+4. Confirm the output `postcode` values are real ZIPs.
+5. Inspect a few unit/subaddress cases and confirm strategy labels are honest.
+6. Capture exact/address counts for the presentation.
+
+Then implement field-mapping preview/validation. That is the next best investment because it converts the Fresno-specific lessons into a tool that any jurisdiction can trust.

--- a/Services/ArcGisNameSanitizer.cs
+++ b/Services/ArcGisNameSanitizer.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+namespace DuckDBGeoparquet.Services
+{
+    public static class ArcGisNameSanitizer
+    {
+        public static string ToFileGeodatabaseFeatureClassName(string value, string fallback = "GERSified_Output", int maxLength = 50)
+        {
+            string safeFallback = string.IsNullOrWhiteSpace(fallback) ? "Output" : fallback;
+            int safeMaxLength = maxLength <= 0 ? 50 : maxLength;
+            var builder = new StringBuilder();
+            bool previousWasUnderscore = false;
+
+            foreach (char ch in value ?? string.Empty)
+            {
+                if (char.IsLetterOrDigit(ch) || ch == '_')
+                {
+                    builder.Append(ch);
+                    previousWasUnderscore = false;
+                }
+                else if (!previousWasUnderscore)
+                {
+                    builder.Append('_');
+                    previousWasUnderscore = true;
+                }
+            }
+
+            string sanitized = builder.ToString().Trim('_');
+            if (string.IsNullOrWhiteSpace(sanitized))
+            {
+                sanitized = safeFallback;
+            }
+
+            if (!char.IsLetter(sanitized[0]))
+            {
+                sanitized = $"fc_{sanitized}";
+            }
+
+            return sanitized.Length > safeMaxLength
+                ? sanitized[..safeMaxLength].TrimEnd('_')
+                : sanitized;
+        }
+    }
+}

--- a/Services/BridgeFileService.cs
+++ b/Services/BridgeFileService.cs
@@ -1,0 +1,76 @@
+using DuckDBGeoparquet.Models;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DuckDBGeoparquet.Services
+{
+    public sealed class BridgeFileService : IDisposable
+    {
+        private readonly DuckDBManager _duckDb = new();
+        private bool _isDisposed;
+
+        public async Task<TraceSourcesResult> TraceSourcesAsync(
+            TraceSourcesOptions options,
+            IProgress<string> progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(options.InputCsvPath) || !File.Exists(options.InputCsvPath))
+                throw new FileNotFoundException("Input GERS ID CSV was not found.", options.InputCsvPath);
+            if (string.IsNullOrWhiteSpace(options.OutputFolder))
+                throw new ArgumentException("Output folder is required.", nameof(options));
+
+            Directory.CreateDirectory(options.OutputFolder);
+            string suffix = GersifyOptions.BuildTimestampSuffix();
+            string outputCsvPath = Path.Combine(options.OutputFolder, $"gers_source_lookup_{suffix}.csv");
+
+            await _duckDb.InitializeAsync(cancellationToken);
+            await ExecuteNonQueryAsync(GersSql.BuildUtilityFunctionsCommand(), cancellationToken);
+
+            progress?.Report("Reading GERS IDs...");
+            await ExecuteNonQueryAsync(GersSql.BuildCreateTraceInputCommand(options.InputCsvPath), cancellationToken);
+            int inputCount = await ExecuteCountAsync(GersSql.TraceInputTable, cancellationToken);
+            if (inputCount == 0)
+            {
+                throw new InvalidOperationException("No GERS IDs were found in the selected layer or table.");
+            }
+
+            progress?.Report("Querying Overture bridge files...");
+            await ExecuteNonQueryAsync(GersSql.BuildTraceSourcesCommand(options, outputCsvPath), cancellationToken);
+            int outputCount = await ExecuteCountAsync(GersSql.TraceOutputTable, cancellationToken);
+
+            return new TraceSourcesResult
+            {
+                InputCount = inputCount,
+                OutputCount = outputCount,
+                OutputCsvPath = outputCsvPath
+            };
+        }
+
+        private async Task ExecuteNonQueryAsync(string sql, CancellationToken cancellationToken)
+        {
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        private async Task<int> ExecuteCountAsync(string tableName, CancellationToken cancellationToken)
+        {
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+            object value = await command.ExecuteScalarAsync(cancellationToken);
+            return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _duckDb.Dispose();
+            _isDisposed = true;
+        }
+    }
+}

--- a/Services/BridgeFileService.cs
+++ b/Services/BridgeFileService.cs
@@ -2,6 +2,7 @@ using DuckDBGeoparquet.Models;
 using System;
 using System.Globalization;
 using System.IO;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -63,8 +64,27 @@ namespace DuckDBGeoparquet.Services
             using var command = _duckDb.Connection.CreateCommand();
             command.CommandText = $"SELECT COUNT(*) FROM {tableName}";
             object value = await command.ExecuteScalarAsync(cancellationToken);
-            return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+            return ReadInt32(value);
         }
+
+        private static int ReadInt32(object value)
+        {
+            if (value == null || value == DBNull.Value)
+                return 0;
+
+            return value switch
+            {
+                int intValue => intValue,
+                long longValue => ClampToInt32(longValue),
+                BigInteger bigIntegerValue => bigIntegerValue > int.MaxValue
+                    ? int.MaxValue
+                    : bigIntegerValue < int.MinValue ? int.MinValue : (int)bigIntegerValue,
+                _ => Convert.ToInt32(value, CultureInfo.InvariantCulture)
+            };
+        }
+
+        private static int ClampToInt32(long value) =>
+            value > int.MaxValue ? int.MaxValue : value < int.MinValue ? int.MinValue : (int)value;
 
         public void Dispose()
         {

--- a/Services/DataProcessor.cs
+++ b/Services/DataProcessor.cs
@@ -122,7 +122,7 @@ namespace DuckDBGeoparquet.Services
                 
                 string schemaQuery = $@"
                     CREATE OR REPLACE TABLE temp AS 
-                    SELECT * FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1) LIMIT 0;
+                    SELECT * FROM read_parquet('{s3Path}', {S3Ingester.S3ReadParquetOptions}) LIMIT 0;
                 ";
                 command.CommandText = schemaQuery;
                 System.Diagnostics.Debug.WriteLine($"Executing schema query for {actualS3Type ?? "data"}...");
@@ -262,7 +262,7 @@ namespace DuckDBGeoparquet.Services
                 using var command = _connection.CreateCommand();
                 command.CommandText = $@"
                     CREATE OR REPLACE TABLE temp_schema AS 
-                    SELECT * FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1) LIMIT 0;
+                    SELECT * FROM read_parquet('{s3Path}', {S3Ingester.S3ReadParquetOptions}) LIMIT 0;
                 ";
                 await command.ExecuteNonQueryAsync(cancellationToken);
 

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -1,0 +1,341 @@
+using DuckDBGeoparquet.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace DuckDBGeoparquet.Services
+{
+    public static class GersSql
+    {
+        public const string UserInputTable = "gers_user_input";
+        public const string CandidateTable = "gers_candidates";
+        public const string AcceptedTable = "gers_accepted";
+        public const string OutputTable = "gers_output";
+        public const string TraceInputTable = "gers_trace_input";
+        public const string TraceOutputTable = "gers_trace_sources";
+
+        public static string BuildCreateUserInputTableCommand(string csvPath)
+        {
+            string escapedPath = Escape(csvPath);
+            return $@"
+                CREATE OR REPLACE TABLE {UserInputTable} AS
+                SELECT
+                    CAST(record_id AS VARCHAR) AS record_id,
+                    CAST(name AS VARCHAR) AS name,
+                    CAST(address AS VARCHAR) AS address,
+                    CAST(city AS VARCHAR) AS city,
+                    CAST(state AS VARCHAR) AS state,
+                    CAST(postcode AS VARCHAR) AS postcode,
+                    CAST(longitude AS DOUBLE) AS longitude,
+                    CAST(latitude AS DOUBLE) AS latitude
+                FROM read_csv('{escapedPath}', header=true, auto_detect=true, ignore_errors=true)
+                WHERE record_id IS NOT NULL
+                  AND longitude IS NOT NULL
+                  AND latitude IS NOT NULL;";
+        }
+
+        public static string BuildPlacesCandidateTablesCommand(
+            string placesParquetGlob,
+            GersifyOptions options,
+            IReadOnlyCollection<string> availableColumns = null)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            string escapedPath = Escape(placesParquetGlob);
+            int candidateLimit = Math.Clamp(options.ReviewCandidatesPerRecord, 1, 25);
+            string maxDistance = Format(options.MaxDistanceMeters);
+            string nameThreshold = Format(options.NameSimilarityThreshold);
+            string addressThreshold = Format(options.AddressSimilarityThreshold);
+            string scoreThreshold = Format(options.AcceptScoreThreshold);
+            string bboxFilter = BuildOvertureBboxFilter(options.InputExtent, availableColumns);
+            string placeNameExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("names", "CAST(names.primary AS VARCHAR)"),
+                ("name", "CAST(name AS VARCHAR)"),
+                ("name_primary", "CAST(name_primary AS VARCHAR)"),
+                ("brand", "CAST(brand AS VARCHAR)"));
+            string placeAddressExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("addresses", "CAST(addresses[1].freeform AS VARCHAR)"),
+                ("address", "CAST(address AS VARCHAR)"),
+                ("street", "CAST(street AS VARCHAR)"),
+                ("full_address", "CAST(full_address AS VARCHAR)"));
+
+            return $@"
+                CREATE OR REPLACE TABLE {CandidateTable} AS
+                WITH user_prepared AS (
+                    SELECT
+                        record_id,
+                        coalesce(name, '') AS user_name,
+                        coalesce(address, '') AS user_address,
+                        coalesce(city, '') AS user_city,
+                        coalesce(state, '') AS user_state,
+                        coalesce(postcode, '') AS user_postcode,
+                        longitude,
+                        latitude,
+                        NormalizeText(coalesce(name, '')) AS user_name_norm,
+                        NormalizeText(trim(concat_ws(' ', coalesce(address, ''), coalesce(city, ''), coalesce(state, ''), coalesce(postcode, '')))) AS user_address_norm
+                    FROM {UserInputTable}
+                ),
+                overture_places AS (
+                    SELECT
+                        CAST(id AS VARCHAR) AS overture_id,
+                        coalesce({placeNameExpr}, '') AS overture_name,
+                        coalesce({placeAddressExpr}, '') AS overture_address,
+                        CAST(ST_X(geometry) AS DOUBLE) AS overture_longitude,
+                        CAST(ST_Y(geometry) AS DOUBLE) AS overture_latitude,
+                        NormalizeText(coalesce({placeNameExpr}, '')) AS overture_name_norm,
+                        NormalizeText(coalesce({placeAddressExpr}, '')) AS overture_address_norm
+                    FROM read_parquet('{escapedPath}', hive_partitioning=1)
+                    WHERE geometry IS NOT NULL
+                    {bboxFilter}
+                ),
+                candidate_distances AS (
+                    SELECT
+                        u.*,
+                        o.overture_id,
+                        o.overture_name,
+                        o.overture_address,
+                        o.overture_longitude,
+                        o.overture_latitude,
+                        sqrt(
+                            pow((o.overture_longitude - u.longitude) * 111320.0 * cos(radians((o.overture_latitude + u.latitude) / 2.0)), 2) +
+                            pow((o.overture_latitude - u.latitude) * 110540.0, 2)
+                        ) AS distance_m
+                    FROM user_prepared u
+                    JOIN overture_places o
+                      ON abs(o.overture_latitude - u.latitude) <= ({maxDistance} / 110540.0)
+                     AND abs(o.overture_longitude - u.longitude) <= ({maxDistance} / greatest(111320.0 * abs(cos(radians(u.latitude))), 1.0))
+                    WHERE u.user_name_norm <> ''
+                      AND o.overture_name_norm <> ''
+                ),
+                scored AS (
+                    SELECT
+                        record_id,
+                        user_name,
+                        user_address,
+                        user_city,
+                        user_state,
+                        user_postcode,
+                        longitude,
+                        latitude,
+                        overture_id AS gers_id,
+                        overture_id,
+                        overture_name,
+                        overture_address,
+                        overture_longitude,
+                        overture_latitude,
+                        distance_m,
+                        jaro_winkler_similarity(user_name_norm, overture_name_norm) AS name_similarity,
+                        CASE
+                            WHEN user_address_norm = '' OR overture_address_norm = '' THEN NULL
+                            ELSE jaro_winkler_similarity(user_address_norm, overture_address_norm)
+                        END AS address_similarity,
+                        greatest(0.0, 1.0 - (distance_m / {maxDistance})) AS distance_similarity
+                    FROM candidate_distances
+                    WHERE distance_m <= {maxDistance}
+                ),
+                ranked AS (
+                    SELECT
+                        *,
+                        (
+                            (name_similarity * 65.0) +
+                            (coalesce(address_similarity, 0.75) * 20.0) +
+                            (distance_similarity * 15.0)
+                        ) AS gers_match_score,
+                        row_number() OVER (
+                            PARTITION BY record_id
+                            ORDER BY
+                                ((name_similarity * 65.0) + (coalesce(address_similarity, 0.75) * 20.0) + (distance_similarity * 15.0)) DESC,
+                                distance_m ASC,
+                                overture_name ASC
+                        ) AS candidate_rank
+                    FROM scored
+                )
+                SELECT
+                    *,
+                    (
+                    candidate_rank = 1
+                    AND name_similarity >= {nameThreshold}
+                    AND (address_similarity IS NULL OR address_similarity >= {addressThreshold})
+                    AND gers_match_score >= {scoreThreshold}
+                    ) AS accepted
+                FROM ranked
+                WHERE candidate_rank <= {candidateLimit};
+
+                CREATE OR REPLACE TABLE {AcceptedTable} AS
+                SELECT *
+                FROM {CandidateTable}
+                WHERE accepted = TRUE
+                  AND candidate_rank = 1;
+
+                CREATE OR REPLACE TABLE {OutputTable} AS
+                SELECT
+                    u.record_id,
+                    u.name,
+                    u.address,
+                    u.city,
+                    u.state,
+                    u.postcode,
+                    u.longitude,
+                    u.latitude,
+                    a.gers_id,
+                    a.gers_match_score,
+                    a.distance_m AS gers_match_distance_m,
+                    a.name_similarity AS gers_name_similarity,
+                    a.address_similarity AS gers_address_similarity,
+                    a.overture_name,
+                    a.overture_id
+                FROM {UserInputTable} u
+                LEFT JOIN {AcceptedTable} a
+                  ON u.record_id = a.record_id;";
+        }
+
+        public static string BuildCopyGersifyOutputsCommand(string outputCsvPath, string candidateCsvPath, string bridgeCsvPath, string datasetName)
+        {
+            string escapedOutputPath = Escape(outputCsvPath);
+            string escapedCandidatePath = Escape(candidateCsvPath);
+            string escapedBridgePath = Escape(bridgeCsvPath);
+            string escapedDataset = Escape(datasetName);
+
+            return $@"
+                COPY {OutputTable} TO '{escapedOutputPath}' (FORMAT CSV, HEADER TRUE);
+                COPY {CandidateTable} TO '{escapedCandidatePath}' (FORMAT CSV, HEADER TRUE);
+                COPY (
+                    SELECT
+                        gers_id AS id,
+                        record_id,
+                        CAST(current_timestamp AS VARCHAR) AS update_time,
+                        '{escapedDataset}' AS dataset,
+                        'places' AS theme,
+                        'place' AS type
+                    FROM {AcceptedTable}
+                    ORDER BY record_id
+                ) TO '{escapedBridgePath}' (FORMAT CSV, HEADER TRUE);";
+        }
+
+        public static string BuildCreateTraceInputCommand(string csvPath)
+        {
+            string escapedPath = Escape(csvPath);
+            return $@"
+                CREATE OR REPLACE TABLE {TraceInputTable} AS
+                SELECT DISTINCT CAST(gers_id AS VARCHAR) AS gers_id
+                FROM read_csv('{escapedPath}', header=true, auto_detect=true, ignore_errors=true)
+                WHERE gers_id IS NOT NULL
+                  AND trim(CAST(gers_id AS VARCHAR)) <> '';";
+        }
+
+        public static string BuildTraceSourcesCommand(TraceSourcesOptions options, string outputCsvPath)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            string bridgeGlob = Escape(BuildBridgeGlob(options.BridgeRoot, options.Release));
+            string outputPath = Escape(outputCsvPath);
+            string theme = Escape(options.Theme);
+            string type = Escape(options.Type);
+            int maxRows = Math.Clamp(options.MaxRows, 1, 1000000);
+
+            return $@"
+                CREATE OR REPLACE TABLE {TraceOutputTable} AS
+                WITH bridge AS (
+                    SELECT
+                        CAST(id AS VARCHAR) AS gers_id,
+                        CAST(record_id AS VARCHAR) AS record_id,
+                        CAST(update_time AS VARCHAR) AS update_time,
+                        CAST(dataset AS VARCHAR) AS dataset,
+                        CAST(theme AS VARCHAR) AS theme,
+                        CAST(type AS VARCHAR) AS type
+                    FROM read_parquet('{bridgeGlob}', hive_partitioning=1)
+                    WHERE theme = '{theme}'
+                      AND type = '{type}'
+                )
+                SELECT
+                    i.gers_id,
+                    b.dataset,
+                    b.record_id,
+                    b.update_time,
+                    b.theme,
+                    b.type,
+                    BuildOsmUrl(b.dataset, b.record_id) AS source_url
+                FROM {TraceInputTable} i
+                JOIN bridge b
+                  ON i.gers_id = b.gers_id
+                ORDER BY i.gers_id, b.dataset, b.record_id
+                LIMIT {maxRows};
+
+                COPY {TraceOutputTable} TO '{outputPath}' (FORMAT CSV, HEADER TRUE);";
+        }
+
+        public static string BuildBridgeGlob(string bridgeRoot, string release)
+        {
+            string root = string.IsNullOrWhiteSpace(bridgeRoot)
+                ? "https://overturemapswestus2.blob.core.windows.net/bridgefiles"
+                : bridgeRoot.Trim().TrimEnd('/', '\\');
+            string safeRelease = string.IsNullOrWhiteSpace(release)
+                ? GersifyOptions.DefaultReleaseVersion
+                : release.Trim();
+
+            return $"{root}/{safeRelease}/**/*.parquet";
+        }
+
+        private static string BuildOvertureBboxFilter(ExtentBounds extent, IReadOnlyCollection<string> availableColumns)
+        {
+            if (extent == null)
+                return string.Empty;
+
+            if (availableColumns != null && !availableColumns.Contains("bbox", StringComparer.OrdinalIgnoreCase))
+                return string.Empty;
+
+            return $@"
+                      AND bbox.xmin <= {Format(extent.XMax)}
+                      AND bbox.xmax >= {Format(extent.XMin)}
+                      AND bbox.ymin <= {Format(extent.YMax)}
+                      AND bbox.ymax >= {Format(extent.YMin)}";
+        }
+
+        private static string BuildFirstExistingExpression(
+            IReadOnlyCollection<string> availableColumns,
+            params (string Column, string Expression)[] expressions)
+        {
+            if (availableColumns == null || availableColumns.Count == 0)
+            {
+                return expressions.Length == 0 ? "''" : expressions[0].Expression;
+            }
+
+            foreach (var (column, expression) in expressions)
+            {
+                if (availableColumns.Contains(column, StringComparer.OrdinalIgnoreCase))
+                {
+                    return expression;
+                }
+            }
+
+            return "''";
+        }
+
+        public static string BuildUtilityFunctionsCommand() => @"
+                CREATE OR REPLACE MACRO NormalizeText(value) AS
+                    regexp_replace(lower(trim(CAST(coalesce(value, '') AS VARCHAR))), '[^a-z0-9]+', ' ', 'g');
+
+                CREATE OR REPLACE MACRO BuildOsmUrl(dataset, record_id) AS
+                    CASE
+                        WHEN dataset IS NULL OR record_id IS NULL OR lower(CAST(dataset AS VARCHAR)) NOT LIKE '%openstreetmap%' THEN NULL
+                        WHEN regexp_matches(CAST(record_id AS VARCHAR), '^n[0-9]+(@.*)?$')
+                            THEN 'https://www.openstreetmap.org/node/' || regexp_extract(CAST(record_id AS VARCHAR), '^n([0-9]+)', 1)
+                        WHEN regexp_matches(CAST(record_id AS VARCHAR), '^w[0-9]+(@.*)?$')
+                            THEN 'https://www.openstreetmap.org/way/' || regexp_extract(CAST(record_id AS VARCHAR), '^w([0-9]+)', 1)
+                        WHEN regexp_matches(CAST(record_id AS VARCHAR), '^r[0-9]+(@.*)?$')
+                            THEN 'https://www.openstreetmap.org/relation/' || regexp_extract(CAST(record_id AS VARCHAR), '^r([0-9]+)', 1)
+                        ELSE NULL
+                    END;";
+
+        private static string Escape(string value) =>
+            GeoParquetSql.EscapeSqlLiteral(value?.Replace('\\', '/') ?? string.Empty);
+
+        private static string Format(double value) =>
+            value.ToString("G", CultureInfo.InvariantCulture);
+    }
+}

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -100,6 +100,8 @@ namespace DuckDBGeoparquet.Services
                         o.overture_address,
                         o.overture_longitude,
                         o.overture_latitude,
+                        o.overture_name_norm,
+                        o.overture_address_norm,
                         sqrt(
                             pow((o.overture_longitude - u.longitude) * 111320.0 * cos(radians((o.overture_latitude + u.latitude) / 2.0)), 2) +
                             pow((o.overture_latitude - u.latitude) * 110540.0, 2)

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -433,7 +433,7 @@ namespace DuckDBGeoparquet.Services
                     SELECT
                         *,
                         CASE
-                            WHEN house_number_match AND postcode_compatible AND address_similarity >= 0.96 THEN 'exact_address'
+                            WHEN house_number_match AND postcode_compatible AND address_similarity >= 0.995 THEN 'exact_address'
                             WHEN address_similarity IS NOT NULL THEN 'address'
                             ELSE 'nearby_only'
                         END AS match_strategy,

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -59,6 +59,7 @@ namespace DuckDBGeoparquet.Services
             string placeAddressExpr = BuildFirstExistingExpression(
                 availableColumns,
                 ("addresses", "CAST(addresses[1].freeform AS VARCHAR)"),
+                ("address_freeform", "CAST(address_freeform AS VARCHAR)"),
                 ("address", "CAST(address AS VARCHAR)"),
                 ("street", "CAST(street AS VARCHAR)"),
                 ("full_address", "CAST(full_address AS VARCHAR)"));
@@ -110,8 +111,8 @@ namespace DuckDBGeoparquet.Services
                     JOIN overture_places o
                       ON abs(o.overture_latitude - u.latitude) <= ({maxDistance} / 110540.0)
                      AND abs(o.overture_longitude - u.longitude) <= ({maxDistance} / greatest(111320.0 * abs(cos(radians(u.latitude))), 1.0))
-                    WHERE u.user_name_norm <> ''
-                      AND o.overture_name_norm <> ''
+                    WHERE (u.user_name_norm <> '' AND o.overture_name_norm <> '')
+                       OR (u.user_address_norm <> '' AND o.overture_address_norm <> '')
                 ),
                 scored AS (
                     SELECT
@@ -130,7 +131,10 @@ namespace DuckDBGeoparquet.Services
                         overture_longitude,
                         overture_latitude,
                         distance_m,
-                        jaro_winkler_similarity(user_name_norm, overture_name_norm) AS name_similarity,
+                        CASE
+                            WHEN user_name_norm = '' OR overture_name_norm = '' THEN NULL
+                            ELSE jaro_winkler_similarity(user_name_norm, overture_name_norm)
+                        END AS name_similarity,
                         CASE
                             WHEN user_address_norm = '' OR overture_address_norm = '' THEN NULL
                             ELSE jaro_winkler_similarity(user_address_norm, overture_address_norm)
@@ -142,15 +146,21 @@ namespace DuckDBGeoparquet.Services
                 ranked AS (
                     SELECT
                         *,
-                        (
-                            (name_similarity * 65.0) +
-                            (coalesce(address_similarity, 0.75) * 20.0) +
-                            (distance_similarity * 15.0)
-                        ) AS gers_match_score,
+                        CASE
+                            WHEN name_similarity IS NULL AND address_similarity IS NULL THEN distance_similarity * 100.0
+                            WHEN name_similarity IS NULL THEN (address_similarity * 80.0) + (distance_similarity * 20.0)
+                            WHEN address_similarity IS NULL THEN (name_similarity * 80.0) + (distance_similarity * 20.0)
+                            ELSE (name_similarity * 60.0) + (address_similarity * 25.0) + (distance_similarity * 15.0)
+                        END AS gers_match_score,
                         row_number() OVER (
                             PARTITION BY record_id
                             ORDER BY
-                                ((name_similarity * 65.0) + (coalesce(address_similarity, 0.75) * 20.0) + (distance_similarity * 15.0)) DESC,
+                                CASE
+                                    WHEN name_similarity IS NULL AND address_similarity IS NULL THEN distance_similarity * 100.0
+                                    WHEN name_similarity IS NULL THEN (address_similarity * 80.0) + (distance_similarity * 20.0)
+                                    WHEN address_similarity IS NULL THEN (name_similarity * 80.0) + (distance_similarity * 20.0)
+                                    ELSE (name_similarity * 60.0) + (address_similarity * 25.0) + (distance_similarity * 15.0)
+                                END DESC,
                                 distance_m ASC,
                                 overture_name ASC
                         ) AS candidate_rank
@@ -160,8 +170,9 @@ namespace DuckDBGeoparquet.Services
                     *,
                     (
                     candidate_rank = 1
-                    AND name_similarity >= {nameThreshold}
+                    AND (name_similarity IS NULL OR name_similarity >= {nameThreshold})
                     AND (address_similarity IS NULL OR address_similarity >= {addressThreshold})
+                    AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)
                     AND gers_match_score >= {scoreThreshold}
                     ) AS accepted
                 FROM ranked

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -14,6 +14,16 @@ namespace DuckDBGeoparquet.Services
         public const string OutputTable = "gers_output";
         public const string TraceInputTable = "gers_trace_input";
         public const string TraceOutputTable = "gers_trace_sources";
+        public const string PlacesReadParquetOptions = "hive_partitioning=1, union_by_name=1";
+
+        private static readonly string[] PlaceAddressColumns =
+        [
+            "address_freeform",
+            "addresses",
+            "address",
+            "street",
+            "full_address"
+        ];
 
         public static string BuildCreateUserInputTableCommand(string csvPath)
         {
@@ -113,7 +123,7 @@ namespace DuckDBGeoparquet.Services
                         NormalizeText(coalesce({placeNameExpr}, '')) AS overture_name_norm,
                         NormalizeText(coalesce({placeStreetAddressExpr}, '')) AS overture_street_norm,
                         NormalizeText(trim(concat_ws(' ', coalesce({placeStreetAddressExpr}, ''), coalesce({placeLocalityExpr}, ''), coalesce({placeRegionExpr}, ''), coalesce({placePostcodeExpr}, '')))) AS overture_address_norm
-                    FROM read_parquet('{escapedPath}', hive_partitioning=1)
+                    FROM read_parquet('{escapedPath}', {PlacesReadParquetOptions})
                     WHERE geometry IS NOT NULL
                     {bboxFilter}
                 ),
@@ -249,6 +259,14 @@ namespace DuckDBGeoparquet.Services
                 FROM {UserInputTable} u
                 LEFT JOIN {AcceptedTable} a
                   ON u.record_id = a.record_id;";
+        }
+
+        public static bool HasPlaceAddressColumns(IReadOnlyCollection<string> availableColumns)
+        {
+            if (availableColumns == null || availableColumns.Count == 0)
+                return true;
+
+            return PlaceAddressColumns.Any(column => availableColumns.Contains(column, StringComparer.OrdinalIgnoreCase));
         }
 
         public static string BuildCopyGersifyOutputsCommand(string outputCsvPath, string candidateCsvPath, string bridgeCsvPath, string datasetName)

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -15,6 +15,7 @@ namespace DuckDBGeoparquet.Services
         public const string TraceInputTable = "gers_trace_input";
         public const string TraceOutputTable = "gers_trace_sources";
         public const string PlacesReadParquetOptions = "hive_partitioning=1, union_by_name=1";
+        public const string AddressesReadParquetOptions = "hive_partitioning=1, union_by_name=1";
 
         private static readonly string[] PlaceAddressColumns =
         [
@@ -23,6 +24,21 @@ namespace DuckDBGeoparquet.Services
             "address",
             "street",
             "full_address"
+        ];
+
+        private static readonly string[] AddressNumberColumns =
+        [
+            "number",
+            "housenumber",
+            "house_number"
+        ];
+
+        private static readonly string[] AddressStreetColumns =
+        [
+            "street",
+            "street_name",
+            "road",
+            "name"
         ];
 
         public static string BuildCreateUserInputTableCommand(string csvPath)
@@ -62,6 +78,14 @@ namespace DuckDBGeoparquet.Services
             string proximityOnlyDistance = Format(Math.Min(
                 options.MaxDistanceMeters,
                 Math.Min(20, Math.Max(5, options.MaxDistanceMeters * 0.2))));
+            string nearbyFallbackAcceptance = options.AllowNearbyOnlyMatches
+                ? $@"
+                        OR (
+                            name_similarity IS NULL
+                            AND address_similarity IS NULL
+                            AND distance_m <= {proximityOnlyDistance}
+                        )"
+                : string.Empty;
             string bboxFilter = BuildOvertureBboxFilter(options.InputExtent, availableColumns);
             string placeNameExpr = BuildFirstExistingExpression(
                 availableColumns,
@@ -222,11 +246,7 @@ namespace DuckDBGeoparquet.Services
                             AND (address_similarity IS NULL OR address_similarity >= {addressThreshold})
                             AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)
                         )
-                        OR (
-                            name_similarity IS NULL
-                            AND address_similarity IS NULL
-                            AND distance_m <= {proximityOnlyDistance}
-                        )
+                        {nearbyFallbackAcceptance}
                     )
                     ) AS accepted
                 FROM ranked
@@ -254,6 +274,221 @@ namespace DuckDBGeoparquet.Services
                     a.distance_m AS gers_match_distance_m,
                     a.name_similarity AS gers_name_similarity,
                     a.address_similarity AS gers_address_similarity,
+                    a.overture_address,
+                    a.overture_name,
+                    a.overture_id
+                FROM {UserInputTable} u
+                LEFT JOIN {AcceptedTable} a
+                  ON u.record_id = a.record_id;";
+        }
+
+        public static string BuildAddressesCandidateTablesCommand(
+            string addressParquetGlob,
+            GersifyOptions options,
+            IReadOnlyCollection<string> availableColumns = null)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            string escapedPath = Escape(addressParquetGlob);
+            int candidateLimit = Math.Clamp(options.ReviewCandidatesPerRecord, 1, 25);
+            string maxDistance = Format(options.MaxDistanceMeters);
+            string addressThreshold = Format(options.AddressSimilarityThreshold);
+            string scoreThreshold = Format(options.AcceptScoreThreshold);
+            string bboxFilter = BuildOvertureBboxFilter(options.InputExtent, availableColumns);
+            string numberExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("number", "CAST(number AS VARCHAR)"),
+                ("housenumber", "CAST(housenumber AS VARCHAR)"),
+                ("house_number", "CAST(house_number AS VARCHAR)"));
+            string streetExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("street", "CAST(street AS VARCHAR)"),
+                ("street_name", "CAST(street_name AS VARCHAR)"),
+                ("road", "CAST(road AS VARCHAR)"),
+                ("name", "CAST(name AS VARCHAR)"));
+            string unitExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("unit", "CAST(unit AS VARCHAR)"),
+                ("address_unit", "CAST(address_unit AS VARCHAR)"),
+                ("suite", "CAST(suite AS VARCHAR)"));
+            string localityExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("postal_city", "CAST(postal_city AS VARCHAR)"),
+                ("city", "CAST(city AS VARCHAR)"),
+                ("locality", "CAST(locality AS VARCHAR)"),
+                ("district", "CAST(district AS VARCHAR)"));
+            string regionExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("region", "CAST(region AS VARCHAR)"),
+                ("state", "CAST(state AS VARCHAR)"),
+                ("province", "CAST(province AS VARCHAR)"));
+            string postcodeExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("postcode", "left(CAST(postcode AS VARCHAR), 5)"),
+                ("postal_code", "left(CAST(postal_code AS VARCHAR), 5)"),
+                ("zip", "left(CAST(zip AS VARCHAR), 5)"));
+            string countryExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("country", "CAST(country AS VARCHAR)"),
+                ("country_code", "CAST(country_code AS VARCHAR)"));
+
+            return $@"
+                CREATE OR REPLACE TABLE {CandidateTable} AS
+                WITH user_prepared AS (
+                    SELECT
+                        record_id,
+                        coalesce(name, '') AS user_name,
+                        coalesce(address, '') AS user_address,
+                        coalesce(city, '') AS user_city,
+                        coalesce(state, '') AS user_state,
+                        coalesce(postcode, '') AS user_postcode,
+                        longitude,
+                        latitude,
+                        NormalizeText(coalesce(address, '')) AS user_street_norm,
+                        NormalizeText(trim(concat_ws(' ', coalesce(address, ''), coalesce(city, ''), coalesce(state, ''), coalesce(postcode, '')))) AS user_address_norm,
+                        regexp_extract(lower(coalesce(address, '')), '^\s*([0-9]+[a-z]?)', 1) AS user_number_norm,
+                        left(regexp_replace(coalesce(postcode, ''), '[^0-9]', '', 'g'), 5) AS user_postcode_norm
+                    FROM {UserInputTable}
+                ),
+                overture_addresses AS (
+                    SELECT
+                        CAST(id AS VARCHAR) AS overture_id,
+                        trim(concat_ws(' ', nullif({numberExpr}, ''), nullif({streetExpr}, ''), nullif({unitExpr}, ''))) AS overture_address,
+                        trim(concat_ws(' ', nullif({numberExpr}, ''), nullif({streetExpr}, ''))) AS overture_street_address,
+                        {numberExpr} AS overture_number,
+                        {postcodeExpr} AS overture_postcode,
+                        CAST(ST_X(geometry) AS DOUBLE) AS overture_longitude,
+                        CAST(ST_Y(geometry) AS DOUBLE) AS overture_latitude,
+                        NormalizeText(trim(concat_ws(' ', nullif({numberExpr}, ''), nullif({streetExpr}, ''), nullif({unitExpr}, '')))) AS overture_street_norm,
+                        NormalizeText(trim(concat_ws(' ', nullif({numberExpr}, ''), nullif({streetExpr}, ''), nullif({unitExpr}, ''), nullif({localityExpr}, ''), nullif({regionExpr}, ''), nullif({postcodeExpr}, ''), nullif({countryExpr}, '')))) AS overture_address_norm,
+                        lower(trim({numberExpr})) AS overture_number_norm,
+                        left(regexp_replace(coalesce({postcodeExpr}, ''), '[^0-9]', '', 'g'), 5) AS overture_postcode_norm
+                    FROM read_parquet('{escapedPath}', {AddressesReadParquetOptions})
+                    WHERE geometry IS NOT NULL
+                    {bboxFilter}
+                ),
+                candidate_distances AS (
+                    SELECT
+                        u.*,
+                        o.overture_id,
+                        o.overture_address,
+                        o.overture_street_address,
+                        o.overture_number,
+                        o.overture_postcode,
+                        o.overture_longitude,
+                        o.overture_latitude,
+                        o.overture_street_norm,
+                        o.overture_address_norm,
+                        o.overture_number_norm,
+                        o.overture_postcode_norm,
+                        sqrt(
+                            pow((o.overture_longitude - u.longitude) * 111320.0 * cos(radians((o.overture_latitude + u.latitude) / 2.0)), 2) +
+                            pow((o.overture_latitude - u.latitude) * 110540.0, 2)
+                        ) AS distance_m
+                    FROM user_prepared u
+                    JOIN overture_addresses o
+                      ON abs(o.overture_latitude - u.latitude) <= ({maxDistance} / 110540.0)
+                     AND abs(o.overture_longitude - u.longitude) <= ({maxDistance} / greatest(111320.0 * abs(cos(radians(u.latitude))), 1.0))
+                    WHERE u.user_street_norm <> ''
+                      AND o.overture_street_norm <> ''
+                ),
+                scored AS (
+                    SELECT
+                        record_id,
+                        user_name,
+                        user_address,
+                        user_city,
+                        user_state,
+                        user_postcode,
+                        longitude,
+                        latitude,
+                        overture_id AS gers_id,
+                        overture_id,
+                        overture_address AS overture_name,
+                        overture_address,
+                        overture_longitude,
+                        overture_latitude,
+                        distance_m,
+                        CAST(NULL AS DOUBLE) AS name_similarity,
+                        greatest(
+                            jaro_winkler_similarity(user_street_norm, overture_street_norm),
+                            jaro_winkler_similarity(user_address_norm, overture_address_norm)
+                        ) AS address_similarity,
+                        greatest(0.0, 1.0 - (distance_m / {maxDistance})) AS distance_similarity,
+                        (
+                            user_number_norm <> ''
+                            AND overture_number_norm <> ''
+                            AND user_number_norm = overture_number_norm
+                        ) AS house_number_match,
+                        (
+                            user_postcode_norm = ''
+                            OR overture_postcode_norm = ''
+                            OR user_postcode_norm = overture_postcode_norm
+                        ) AS postcode_compatible
+                    FROM candidate_distances
+                    WHERE distance_m <= {maxDistance}
+                ),
+                ranked AS (
+                    SELECT
+                        *,
+                        CASE
+                            WHEN house_number_match AND postcode_compatible AND address_similarity >= 0.96 THEN 'exact_address'
+                            WHEN address_similarity IS NOT NULL THEN 'address'
+                            ELSE 'nearby_only'
+                        END AS match_strategy,
+                        CASE
+                            WHEN house_number_match AND postcode_compatible THEN (address_similarity * 90.0) + (distance_similarity * 10.0)
+                            ELSE (address_similarity * 70.0) + (distance_similarity * 10.0)
+                        END AS gers_match_score,
+                        row_number() OVER (
+                            PARTITION BY record_id
+                            ORDER BY
+                                CASE WHEN house_number_match AND postcode_compatible THEN 0 ELSE 1 END ASC,
+                                CASE
+                                    WHEN house_number_match AND postcode_compatible THEN (address_similarity * 90.0) + (distance_similarity * 10.0)
+                                    ELSE (address_similarity * 70.0) + (distance_similarity * 10.0)
+                                END DESC,
+                                distance_m ASC,
+                                overture_address ASC
+                        ) AS candidate_rank
+                    FROM scored
+                )
+                SELECT
+                    *,
+                    (
+                        candidate_rank = 1
+                        AND gers_match_score >= {scoreThreshold}
+                        AND address_similarity >= {addressThreshold}
+                        AND house_number_match
+                        AND postcode_compatible
+                    ) AS accepted
+                FROM ranked
+                WHERE candidate_rank <= {candidateLimit};
+
+                CREATE OR REPLACE TABLE {AcceptedTable} AS
+                SELECT *
+                FROM {CandidateTable}
+                WHERE accepted = TRUE
+                  AND candidate_rank = 1;
+
+                CREATE OR REPLACE TABLE {OutputTable} AS
+                SELECT
+                    u.record_id,
+                    u.name,
+                    u.address,
+                    u.city,
+                    u.state,
+                    u.postcode,
+                    u.longitude,
+                    u.latitude,
+                    a.gers_id,
+                    a.gers_match_score,
+                    a.match_strategy AS gers_match_strategy,
+                    a.distance_m AS gers_match_distance_m,
+                    a.name_similarity AS gers_name_similarity,
+                    a.address_similarity AS gers_address_similarity,
+                    a.overture_address,
                     a.overture_name,
                     a.overture_id
                 FROM {UserInputTable} u
@@ -269,12 +504,29 @@ namespace DuckDBGeoparquet.Services
             return PlaceAddressColumns.Any(column => availableColumns.Contains(column, StringComparer.OrdinalIgnoreCase));
         }
 
-        public static string BuildCopyGersifyOutputsCommand(string outputCsvPath, string candidateCsvPath, string bridgeCsvPath, string datasetName)
+        public static bool HasAddressDatasetColumns(IReadOnlyCollection<string> availableColumns)
+        {
+            if (availableColumns == null || availableColumns.Count == 0)
+                return true;
+
+            return AddressNumberColumns.Any(column => availableColumns.Contains(column, StringComparer.OrdinalIgnoreCase)) &&
+                   AddressStreetColumns.Any(column => availableColumns.Contains(column, StringComparer.OrdinalIgnoreCase));
+        }
+
+        public static string BuildCopyGersifyOutputsCommand(
+            string outputCsvPath,
+            string candidateCsvPath,
+            string bridgeCsvPath,
+            string datasetName,
+            string theme = "places",
+            string type = "place")
         {
             string escapedOutputPath = Escape(outputCsvPath);
             string escapedCandidatePath = Escape(candidateCsvPath);
             string escapedBridgePath = Escape(bridgeCsvPath);
             string escapedDataset = Escape(datasetName);
+            string escapedTheme = Escape(theme);
+            string escapedType = Escape(type);
 
             return $@"
                 COPY {OutputTable} TO '{escapedOutputPath}' (FORMAT CSV, HEADER TRUE);
@@ -285,8 +537,8 @@ namespace DuckDBGeoparquet.Services
                         record_id,
                         CAST(current_timestamp AS VARCHAR) AS update_time,
                         '{escapedDataset}' AS dataset,
-                        'places' AS theme,
-                        'place' AS type
+                        '{escapedTheme}' AS theme,
+                        '{escapedType}' AS type
                     FROM {AcceptedTable}
                     ORDER BY record_id
                 ) TO '{escapedBridgePath}' (FORMAT CSV, HEADER TRUE);";

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -61,24 +61,27 @@ namespace DuckDBGeoparquet.Services
                 ("brand", "CAST(brand AS VARCHAR)"));
             string placeStreetAddressExpr = BuildFirstExistingExpression(
                 availableColumns,
-                ("addresses", "CAST(addresses[1].freeform AS VARCHAR)"),
                 ("address_freeform", "CAST(address_freeform AS VARCHAR)"),
+                ("addresses", "(SELECT string_agg(CAST(a.freeform AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.freeform IS NOT NULL AND trim(CAST(a.freeform AS VARCHAR)) <> '')"),
                 ("address", "CAST(address AS VARCHAR)"),
                 ("street", "CAST(street AS VARCHAR)"),
                 ("full_address", "CAST(full_address AS VARCHAR)"));
             string placeLocalityExpr = BuildFirstExistingExpression(
                 availableColumns,
-                ("addresses", "CAST(addresses[1].locality AS VARCHAR)"),
+                ("address_locality", "CAST(address_locality AS VARCHAR)"),
+                ("addresses", "(SELECT string_agg(DISTINCT CAST(a.locality AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.locality IS NOT NULL AND trim(CAST(a.locality AS VARCHAR)) <> '')"),
                 ("locality", "CAST(locality AS VARCHAR)"),
                 ("city", "CAST(city AS VARCHAR)"));
             string placeRegionExpr = BuildFirstExistingExpression(
                 availableColumns,
-                ("addresses", "CAST(addresses[1].region AS VARCHAR)"),
+                ("address_region", "CAST(address_region AS VARCHAR)"),
+                ("addresses", "(SELECT string_agg(DISTINCT CAST(a.region AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.region IS NOT NULL AND trim(CAST(a.region AS VARCHAR)) <> '')"),
                 ("region", "CAST(region AS VARCHAR)"),
                 ("state", "CAST(state AS VARCHAR)"));
             string placePostcodeExpr = BuildFirstExistingExpression(
                 availableColumns,
-                ("addresses", "left(CAST(addresses[1].postcode AS VARCHAR), 5)"),
+                ("address_postcode", "left(CAST(address_postcode AS VARCHAR), 5)"),
+                ("addresses", "(SELECT string_agg(DISTINCT left(CAST(a.postcode AS VARCHAR), 5), ' | ') FROM unnest(addresses) AS t(a) WHERE a.postcode IS NOT NULL AND trim(CAST(a.postcode AS VARCHAR)) <> '')"),
                 ("postcode", "left(CAST(postcode AS VARCHAR), 5)"),
                 ("postal_code", "left(CAST(postal_code AS VARCHAR), 5)"),
                 ("zip", "left(CAST(zip AS VARCHAR), 5)"));

--- a/Services/GersSql.cs
+++ b/Services/GersSql.cs
@@ -49,6 +49,9 @@ namespace DuckDBGeoparquet.Services
             string nameThreshold = Format(options.NameSimilarityThreshold);
             string addressThreshold = Format(options.AddressSimilarityThreshold);
             string scoreThreshold = Format(options.AcceptScoreThreshold);
+            string proximityOnlyDistance = Format(Math.Min(
+                options.MaxDistanceMeters,
+                Math.Min(20, Math.Max(5, options.MaxDistanceMeters * 0.2))));
             string bboxFilter = BuildOvertureBboxFilter(options.InputExtent, availableColumns);
             string placeNameExpr = BuildFirstExistingExpression(
                 availableColumns,
@@ -56,13 +59,29 @@ namespace DuckDBGeoparquet.Services
                 ("name", "CAST(name AS VARCHAR)"),
                 ("name_primary", "CAST(name_primary AS VARCHAR)"),
                 ("brand", "CAST(brand AS VARCHAR)"));
-            string placeAddressExpr = BuildFirstExistingExpression(
+            string placeStreetAddressExpr = BuildFirstExistingExpression(
                 availableColumns,
                 ("addresses", "CAST(addresses[1].freeform AS VARCHAR)"),
                 ("address_freeform", "CAST(address_freeform AS VARCHAR)"),
                 ("address", "CAST(address AS VARCHAR)"),
                 ("street", "CAST(street AS VARCHAR)"),
                 ("full_address", "CAST(full_address AS VARCHAR)"));
+            string placeLocalityExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("addresses", "CAST(addresses[1].locality AS VARCHAR)"),
+                ("locality", "CAST(locality AS VARCHAR)"),
+                ("city", "CAST(city AS VARCHAR)"));
+            string placeRegionExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("addresses", "CAST(addresses[1].region AS VARCHAR)"),
+                ("region", "CAST(region AS VARCHAR)"),
+                ("state", "CAST(state AS VARCHAR)"));
+            string placePostcodeExpr = BuildFirstExistingExpression(
+                availableColumns,
+                ("addresses", "left(CAST(addresses[1].postcode AS VARCHAR), 5)"),
+                ("postcode", "left(CAST(postcode AS VARCHAR), 5)"),
+                ("postal_code", "left(CAST(postal_code AS VARCHAR), 5)"),
+                ("zip", "left(CAST(zip AS VARCHAR), 5)"));
 
             return $@"
                 CREATE OR REPLACE TABLE {CandidateTable} AS
@@ -77,6 +96,7 @@ namespace DuckDBGeoparquet.Services
                         longitude,
                         latitude,
                         NormalizeText(coalesce(name, '')) AS user_name_norm,
+                        NormalizeText(coalesce(address, '')) AS user_street_norm,
                         NormalizeText(trim(concat_ws(' ', coalesce(address, ''), coalesce(city, ''), coalesce(state, ''), coalesce(postcode, '')))) AS user_address_norm
                     FROM {UserInputTable}
                 ),
@@ -84,11 +104,12 @@ namespace DuckDBGeoparquet.Services
                     SELECT
                         CAST(id AS VARCHAR) AS overture_id,
                         coalesce({placeNameExpr}, '') AS overture_name,
-                        coalesce({placeAddressExpr}, '') AS overture_address,
+                        coalesce({placeStreetAddressExpr}, '') AS overture_address,
                         CAST(ST_X(geometry) AS DOUBLE) AS overture_longitude,
                         CAST(ST_Y(geometry) AS DOUBLE) AS overture_latitude,
                         NormalizeText(coalesce({placeNameExpr}, '')) AS overture_name_norm,
-                        NormalizeText(coalesce({placeAddressExpr}, '')) AS overture_address_norm
+                        NormalizeText(coalesce({placeStreetAddressExpr}, '')) AS overture_street_norm,
+                        NormalizeText(trim(concat_ws(' ', coalesce({placeStreetAddressExpr}, ''), coalesce({placeLocalityExpr}, ''), coalesce({placeRegionExpr}, ''), coalesce({placePostcodeExpr}, '')))) AS overture_address_norm
                     FROM read_parquet('{escapedPath}', hive_partitioning=1)
                     WHERE geometry IS NOT NULL
                     {bboxFilter}
@@ -102,6 +123,7 @@ namespace DuckDBGeoparquet.Services
                         o.overture_longitude,
                         o.overture_latitude,
                         o.overture_name_norm,
+                        o.overture_street_norm,
                         o.overture_address_norm,
                         sqrt(
                             pow((o.overture_longitude - u.longitude) * 111320.0 * cos(radians((o.overture_latitude + u.latitude) / 2.0)), 2) +
@@ -112,7 +134,8 @@ namespace DuckDBGeoparquet.Services
                       ON abs(o.overture_latitude - u.latitude) <= ({maxDistance} / 110540.0)
                      AND abs(o.overture_longitude - u.longitude) <= ({maxDistance} / greatest(111320.0 * abs(cos(radians(u.latitude))), 1.0))
                     WHERE (u.user_name_norm <> '' AND o.overture_name_norm <> '')
-                       OR (u.user_address_norm <> '' AND o.overture_address_norm <> '')
+                       OR (u.user_street_norm <> '' AND o.overture_street_norm <> '')
+                       OR (u.user_name_norm = '' AND u.user_street_norm <> '' AND o.overture_name_norm <> '')
                 ),
                 scored AS (
                     SELECT
@@ -136,8 +159,11 @@ namespace DuckDBGeoparquet.Services
                             ELSE jaro_winkler_similarity(user_name_norm, overture_name_norm)
                         END AS name_similarity,
                         CASE
-                            WHEN user_address_norm = '' OR overture_address_norm = '' THEN NULL
-                            ELSE jaro_winkler_similarity(user_address_norm, overture_address_norm)
+                            WHEN user_street_norm = '' OR overture_street_norm = '' THEN NULL
+                            ELSE greatest(
+                                jaro_winkler_similarity(user_street_norm, overture_street_norm),
+                                jaro_winkler_similarity(user_address_norm, overture_address_norm)
+                            )
                         END AS address_similarity,
                         greatest(0.0, 1.0 - (distance_m / {maxDistance})) AS distance_similarity
                     FROM candidate_distances
@@ -146,6 +172,12 @@ namespace DuckDBGeoparquet.Services
                 ranked AS (
                     SELECT
                         *,
+                        CASE
+                            WHEN name_similarity IS NOT NULL AND address_similarity IS NOT NULL THEN 'name_address'
+                            WHEN name_similarity IS NOT NULL THEN 'name'
+                            WHEN address_similarity IS NOT NULL THEN 'address'
+                            ELSE 'nearby_only'
+                        END AS match_strategy,
                         CASE
                             WHEN name_similarity IS NULL AND address_similarity IS NULL THEN distance_similarity * 100.0
                             WHEN name_similarity IS NULL THEN (address_similarity * 80.0) + (distance_similarity * 20.0)
@@ -170,10 +202,19 @@ namespace DuckDBGeoparquet.Services
                     *,
                     (
                     candidate_rank = 1
-                    AND (name_similarity IS NULL OR name_similarity >= {nameThreshold})
-                    AND (address_similarity IS NULL OR address_similarity >= {addressThreshold})
-                    AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)
                     AND gers_match_score >= {scoreThreshold}
+                    AND (
+                        (
+                            (name_similarity IS NULL OR name_similarity >= {nameThreshold})
+                            AND (address_similarity IS NULL OR address_similarity >= {addressThreshold})
+                            AND (name_similarity IS NOT NULL OR address_similarity IS NOT NULL)
+                        )
+                        OR (
+                            name_similarity IS NULL
+                            AND address_similarity IS NULL
+                            AND distance_m <= {proximityOnlyDistance}
+                        )
+                    )
                     ) AS accepted
                 FROM ranked
                 WHERE candidate_rank <= {candidateLimit};
@@ -196,6 +237,7 @@ namespace DuckDBGeoparquet.Services
                     u.latitude,
                     a.gers_id,
                     a.gers_match_score,
+                    a.match_strategy AS gers_match_strategy,
                     a.distance_m AS gers_match_distance_m,
                     a.name_similarity AS gers_name_similarity,
                     a.address_similarity AS gers_address_similarity,

--- a/Services/GersifyService.cs
+++ b/Services/GersifyService.cs
@@ -61,8 +61,19 @@ namespace DuckDBGeoparquet.Services
             }
             var inputSignalCounts = await ReadInputSignalCountsAsync(cancellationToken);
 
-            progress?.Report($"Matching {inputCount:N0} point feature(s) to Overture Places...");
+            progress?.Report("Checking selected Overture Places files...");
             var placeColumns = await ReadParquetColumnsAsync(placesGlob, cancellationToken);
+            if (inputSignalCounts.NameCount == 0 &&
+                inputSignalCounts.AddressCount > 0 &&
+                !GersSql.HasPlaceAddressColumns(placeColumns))
+            {
+                throw new InvalidOperationException(
+                    "The selected Overture Places files do not contain place address fields that GERSify can compare. " +
+                    "Your input has address text but no names, so this run would only produce nearby_only matches. " +
+                    "Close any map layers or tables using the old Places Parquet files, re-download Places with this add-in version, then choose that release folder again.");
+            }
+
+            progress?.Report($"Matching {inputCount:N0} point feature(s) to Overture Places...");
             await ExecuteNonQueryAsync(GersSql.BuildPlacesCandidateTablesCommand(placesGlob, options, placeColumns), cancellationToken);
 
             progress?.Report("Writing GERSify outputs...");
@@ -136,7 +147,7 @@ namespace DuckDBGeoparquet.Services
             string escapedPath = GeoParquetSql.EscapeSqlLiteral(parquetGlob.Replace('\\', '/'));
             await ExecuteNonQueryAsync($@"
                 CREATE OR REPLACE TABLE gers_place_schema_probe AS
-                SELECT * FROM read_parquet('{escapedPath}', hive_partitioning=1) LIMIT 0;", cancellationToken);
+                SELECT * FROM read_parquet('{escapedPath}', {GersSql.PlacesReadParquetOptions}) LIMIT 0;", cancellationToken);
 
             var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using var command = _duckDb.Connection.CreateCommand();

--- a/Services/GersifyService.cs
+++ b/Services/GersifyService.cs
@@ -75,6 +75,7 @@ namespace DuckDBGeoparquet.Services
                 cancellationToken);
 
             int candidateCount = await ExecuteCountAsync(GersSql.CandidateTable, cancellationToken);
+            var candidateSignalCounts = await ReadCandidateSignalCountsAsync(cancellationToken);
             int acceptedCount = await ExecuteCountAsync(GersSql.AcceptedTable, cancellationToken);
             var acceptedMatches = await ReadAcceptedMatchesAsync(cancellationToken);
 
@@ -84,6 +85,8 @@ namespace DuckDBGeoparquet.Services
                 InputNameCount = inputSignalCounts.NameCount,
                 InputAddressCount = inputSignalCounts.AddressCount,
                 CandidateCount = candidateCount,
+                CandidateOvertureAddressCount = candidateSignalCounts.OvertureAddressCount,
+                CandidateAddressSimilarityCount = candidateSignalCounts.AddressSimilarityCount,
                 AcceptedCount = acceptedCount,
                 OutputCsvPath = outputCsvPath,
                 CandidateCsvPath = candidatesCsvPath,
@@ -100,6 +103,24 @@ namespace DuckDBGeoparquet.Services
                     sum(CASE WHEN trim(coalesce(name, '')) <> '' THEN 1 ELSE 0 END) AS name_count,
                     sum(CASE WHEN trim(coalesce(address, '')) <> '' THEN 1 ELSE 0 END) AS address_count
                 FROM {GersSql.UserInputTable};";
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+                return (0, 0);
+
+            return (
+                ReadInt32(reader.GetValue(0)),
+                ReadInt32(reader.GetValue(1)));
+        }
+
+        private async Task<(int OvertureAddressCount, int AddressSimilarityCount)> ReadCandidateSignalCountsAsync(CancellationToken cancellationToken)
+        {
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = $@"
+                SELECT
+                    sum(CASE WHEN trim(coalesce(overture_address, '')) <> '' THEN 1 ELSE 0 END) AS overture_address_count,
+                    sum(CASE WHEN address_similarity IS NOT NULL THEN 1 ELSE 0 END) AS address_similarity_count
+                FROM {GersSql.CandidateTable};";
 
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (!await reader.ReadAsync(cancellationToken))

--- a/Services/GersifyService.cs
+++ b/Services/GersifyService.cs
@@ -1,0 +1,221 @@
+using DuckDBGeoparquet.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DuckDBGeoparquet.Services
+{
+    public sealed class GersifyService : IDisposable
+    {
+        private readonly DuckDBManager _duckDb;
+        private bool _isDisposed;
+
+        public GersifyService()
+        {
+            _duckDb = new DuckDBManager();
+        }
+
+        public async Task<GersifyResult> GersifyPlacesAsync(
+            GersifyOptions options,
+            IProgress<string> progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(options.InputCsvPath) || !File.Exists(options.InputCsvPath))
+                throw new FileNotFoundException("Input CSV was not found.", options.InputCsvPath);
+            if (string.IsNullOrWhiteSpace(options.OvertureReleaseFolder) || !Directory.Exists(options.OvertureReleaseFolder))
+                throw new DirectoryNotFoundException($"Overture release folder was not found: {options.OvertureReleaseFolder}");
+            if (string.IsNullOrWhiteSpace(options.OutputFolder))
+                throw new ArgumentException("Output folder is required.", nameof(options));
+
+            Directory.CreateDirectory(options.OutputFolder);
+
+            string placesGlob = ResolvePlacesParquetGlob(options.OvertureReleaseFolder);
+            if (string.IsNullOrWhiteSpace(placesGlob))
+            {
+                throw new FileNotFoundException(
+                    "Could not find downloaded Overture Places GeoParquet files. Load Places first or choose a release folder containing a 'place' subfolder.");
+            }
+
+            string suffix = GersifyOptions.BuildTimestampSuffix();
+            string outputCsvPath = Path.Combine(options.OutputFolder, $"gersified_points_{suffix}.csv");
+            string candidatesCsvPath = Path.Combine(options.OutputFolder, $"gersify_candidates_{suffix}.csv");
+            string bridgeCsvPath = Path.Combine(options.OutputFolder, $"gers_bridge_{suffix}.csv");
+
+            await _duckDb.InitializeAsync(cancellationToken);
+            await ExecuteNonQueryAsync(GersSql.BuildUtilityFunctionsCommand(), cancellationToken);
+
+            progress?.Report("Reading input feature export...");
+            await ExecuteNonQueryAsync(GersSql.BuildCreateUserInputTableCommand(options.InputCsvPath), cancellationToken);
+
+            int inputCount = await ExecuteCountAsync(GersSql.UserInputTable, cancellationToken);
+            if (inputCount == 0)
+            {
+                throw new InvalidOperationException("No valid point features were exported from the selected layer.");
+            }
+
+            progress?.Report($"Matching {inputCount:N0} point feature(s) to Overture Places...");
+            var placeColumns = await ReadParquetColumnsAsync(placesGlob, cancellationToken);
+            await ExecuteNonQueryAsync(GersSql.BuildPlacesCandidateTablesCommand(placesGlob, options, placeColumns), cancellationToken);
+
+            progress?.Report("Writing GERSify outputs...");
+            await ExecuteNonQueryAsync(
+                GersSql.BuildCopyGersifyOutputsCommand(
+                    outputCsvPath,
+                    candidatesCsvPath,
+                    bridgeCsvPath,
+                    string.IsNullOrWhiteSpace(options.DatasetName) ? "user_data" : options.DatasetName),
+                cancellationToken);
+
+            int candidateCount = await ExecuteCountAsync(GersSql.CandidateTable, cancellationToken);
+            int acceptedCount = await ExecuteCountAsync(GersSql.AcceptedTable, cancellationToken);
+            var acceptedMatches = await ReadAcceptedMatchesAsync(cancellationToken);
+
+            return new GersifyResult
+            {
+                InputCount = inputCount,
+                CandidateCount = candidateCount,
+                AcceptedCount = acceptedCount,
+                OutputCsvPath = outputCsvPath,
+                CandidateCsvPath = candidatesCsvPath,
+                BridgeCsvPath = bridgeCsvPath,
+                AcceptedMatches = acceptedMatches
+            };
+        }
+
+        private async Task<IReadOnlyCollection<string>> ReadParquetColumnsAsync(string parquetGlob, CancellationToken cancellationToken)
+        {
+            string escapedPath = GeoParquetSql.EscapeSqlLiteral(parquetGlob.Replace('\\', '/'));
+            await ExecuteNonQueryAsync($@"
+                CREATE OR REPLACE TABLE gers_place_schema_probe AS
+                SELECT * FROM read_parquet('{escapedPath}', hive_partitioning=1) LIMIT 0;", cancellationToken);
+
+            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = "DESCRIBE gers_place_schema_probe";
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                if (!reader.IsDBNull(0))
+                {
+                    columns.Add(reader.GetString(0));
+                }
+            }
+
+            return columns;
+        }
+
+        private async Task<List<GersMatchCandidate>> ReadAcceptedMatchesAsync(CancellationToken cancellationToken)
+        {
+            var matches = new List<GersMatchCandidate>();
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = $@"
+                SELECT
+                    record_id,
+                    user_name,
+                    user_address,
+                    longitude,
+                    latitude,
+                    gers_id,
+                    overture_id,
+                    overture_name,
+                    distance_m,
+                    name_similarity,
+                    address_similarity,
+                    gers_match_score,
+                    candidate_rank,
+                    accepted
+                FROM {GersSql.AcceptedTable}
+                ORDER BY record_id;";
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                matches.Add(new GersMatchCandidate
+                {
+                    RecordId = ReadString(reader, 0),
+                    UserName = ReadString(reader, 1),
+                    UserAddress = ReadString(reader, 2),
+                    Longitude = ReadDouble(reader, 3),
+                    Latitude = ReadDouble(reader, 4),
+                    GersId = ReadString(reader, 5),
+                    OvertureId = ReadString(reader, 6),
+                    OvertureName = ReadString(reader, 7),
+                    DistanceMeters = ReadDouble(reader, 8),
+                    NameSimilarity = ReadDouble(reader, 9),
+                    AddressSimilarity = reader.IsDBNull(10) ? null : ReadDouble(reader, 10),
+                    MatchScore = ReadDouble(reader, 11),
+                    CandidateRank = reader.IsDBNull(12) ? 0 : Convert.ToInt32(reader.GetValue(12), CultureInfo.InvariantCulture),
+                    Accepted = !reader.IsDBNull(13) && Convert.ToBoolean(reader.GetValue(13), CultureInfo.InvariantCulture)
+                });
+            }
+
+            return matches;
+        }
+
+        private static string ResolvePlacesParquetGlob(string releaseFolder)
+        {
+            if (string.IsNullOrWhiteSpace(releaseFolder) || !Directory.Exists(releaseFolder))
+                return null;
+
+            string[] candidateDirectories =
+            [
+                Path.Combine(releaseFolder, "place"),
+                Path.Combine(releaseFolder, "places", "place"),
+                Path.Combine(releaseFolder, "theme=places", "type=place")
+            ];
+
+            foreach (string directory in candidateDirectories)
+            {
+                if (Directory.Exists(directory) &&
+                    Directory.EnumerateFiles(directory, "*.parquet", SearchOption.TopDirectoryOnly).Any())
+                {
+                    return Path.Combine(directory, "*.parquet").Replace('\\', '/');
+                }
+            }
+
+            var nestedPlaceDirectory = new DirectoryInfo(releaseFolder)
+                .EnumerateDirectories("*", SearchOption.AllDirectories)
+                .FirstOrDefault(directory =>
+                    string.Equals(directory.Name, "place", StringComparison.OrdinalIgnoreCase) &&
+                    directory.EnumerateFiles("*.parquet", SearchOption.TopDirectoryOnly).Any());
+
+            return nestedPlaceDirectory == null
+                ? null
+                : Path.Combine(nestedPlaceDirectory.FullName, "*.parquet").Replace('\\', '/');
+        }
+
+        private async Task ExecuteNonQueryAsync(string sql, CancellationToken cancellationToken)
+        {
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        private async Task<int> ExecuteCountAsync(string tableName, CancellationToken cancellationToken)
+        {
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+            object value = await command.ExecuteScalarAsync(cancellationToken);
+            return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+        }
+
+        private static string ReadString(System.Data.Common.DbDataReader reader, int index) =>
+            reader.IsDBNull(index) ? string.Empty : Convert.ToString(reader.GetValue(index), CultureInfo.InvariantCulture) ?? string.Empty;
+
+        private static double ReadDouble(System.Data.Common.DbDataReader reader, int index) =>
+            reader.IsDBNull(index) ? 0 : Convert.ToDouble(reader.GetValue(index), CultureInfo.InvariantCulture);
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _duckDb.Dispose();
+            _isDisposed = true;
+        }
+    }
+}

--- a/Services/GersifyService.cs
+++ b/Services/GersifyService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -105,8 +106,8 @@ namespace DuckDBGeoparquet.Services
                 return (0, 0);
 
             return (
-                reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0), CultureInfo.InvariantCulture),
-                reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture));
+                ReadInt32(reader.GetValue(0)),
+                ReadInt32(reader.GetValue(1)));
         }
 
         private async Task<IReadOnlyCollection<string>> ReadParquetColumnsAsync(string parquetGlob, CancellationToken cancellationToken)
@@ -171,7 +172,7 @@ namespace DuckDBGeoparquet.Services
                     NameSimilarity = ReadDouble(reader, 9),
                     AddressSimilarity = reader.IsDBNull(10) ? null : ReadDouble(reader, 10),
                     MatchScore = ReadDouble(reader, 11),
-                    CandidateRank = reader.IsDBNull(12) ? 0 : Convert.ToInt32(reader.GetValue(12), CultureInfo.InvariantCulture),
+                    CandidateRank = reader.IsDBNull(12) ? 0 : ReadInt32(reader.GetValue(12)),
                     Accepted = !reader.IsDBNull(13) && Convert.ToBoolean(reader.GetValue(13), CultureInfo.InvariantCulture)
                 });
             }
@@ -223,7 +224,7 @@ namespace DuckDBGeoparquet.Services
             using var command = _duckDb.Connection.CreateCommand();
             command.CommandText = $"SELECT COUNT(*) FROM {tableName}";
             object value = await command.ExecuteScalarAsync(cancellationToken);
-            return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+            return ReadInt32(value);
         }
 
         private static string ReadString(System.Data.Common.DbDataReader reader, int index) =>
@@ -231,6 +232,25 @@ namespace DuckDBGeoparquet.Services
 
         private static double ReadDouble(System.Data.Common.DbDataReader reader, int index) =>
             reader.IsDBNull(index) ? 0 : Convert.ToDouble(reader.GetValue(index), CultureInfo.InvariantCulture);
+
+        private static int ReadInt32(object value)
+        {
+            if (value == null || value == DBNull.Value)
+                return 0;
+
+            return value switch
+            {
+                int intValue => intValue,
+                long longValue => ClampToInt32(longValue),
+                BigInteger bigIntegerValue => bigIntegerValue > int.MaxValue
+                    ? int.MaxValue
+                    : bigIntegerValue < int.MinValue ? int.MinValue : (int)bigIntegerValue,
+                _ => Convert.ToInt32(value, CultureInfo.InvariantCulture)
+            };
+        }
+
+        private static int ClampToInt32(long value) =>
+            value > int.MaxValue ? int.MaxValue : value < int.MinValue ? int.MinValue : (int)value;
 
         public void Dispose()
         {

--- a/Services/GersifyService.cs
+++ b/Services/GersifyService.cs
@@ -58,6 +58,7 @@ namespace DuckDBGeoparquet.Services
             {
                 throw new InvalidOperationException("No valid point features were exported from the selected layer.");
             }
+            var inputSignalCounts = await ReadInputSignalCountsAsync(cancellationToken);
 
             progress?.Report($"Matching {inputCount:N0} point feature(s) to Overture Places...");
             var placeColumns = await ReadParquetColumnsAsync(placesGlob, cancellationToken);
@@ -79,6 +80,8 @@ namespace DuckDBGeoparquet.Services
             return new GersifyResult
             {
                 InputCount = inputCount,
+                InputNameCount = inputSignalCounts.NameCount,
+                InputAddressCount = inputSignalCounts.AddressCount,
                 CandidateCount = candidateCount,
                 AcceptedCount = acceptedCount,
                 OutputCsvPath = outputCsvPath,
@@ -86,6 +89,24 @@ namespace DuckDBGeoparquet.Services
                 BridgeCsvPath = bridgeCsvPath,
                 AcceptedMatches = acceptedMatches
             };
+        }
+
+        private async Task<(int NameCount, int AddressCount)> ReadInputSignalCountsAsync(CancellationToken cancellationToken)
+        {
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = $@"
+                SELECT
+                    sum(CASE WHEN trim(coalesce(name, '')) <> '' THEN 1 ELSE 0 END) AS name_count,
+                    sum(CASE WHEN trim(coalesce(address, '')) <> '' THEN 1 ELSE 0 END) AS address_count
+                FROM {GersSql.UserInputTable};";
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+                return (0, 0);
+
+            return (
+                reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0), CultureInfo.InvariantCulture),
+                reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture));
         }
 
         private async Task<IReadOnlyCollection<string>> ReadParquetColumnsAsync(string parquetGlob, CancellationToken cancellationToken)

--- a/Services/GersifyService.cs
+++ b/Services/GersifyService.cs
@@ -20,7 +20,18 @@ namespace DuckDBGeoparquet.Services
             _duckDb = new DuckDBManager();
         }
 
-        public async Task<GersifyResult> GersifyPlacesAsync(
+        public Task<GersifyResult> GersifyPlacesAsync(
+            GersifyOptions options,
+            IProgress<string> progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (options != null)
+                options.TargetType = GersifyTargetType.Places;
+
+            return GersifyAsync(options, progress, cancellationToken);
+        }
+
+        public async Task<GersifyResult> GersifyAsync(
             GersifyOptions options,
             IProgress<string> progress = null,
             CancellationToken cancellationToken = default)
@@ -36,11 +47,11 @@ namespace DuckDBGeoparquet.Services
 
             Directory.CreateDirectory(options.OutputFolder);
 
-            string placesGlob = ResolvePlacesParquetGlob(options.OvertureReleaseFolder);
-            if (string.IsNullOrWhiteSpace(placesGlob))
+            string targetGlob = ResolveTargetParquetGlob(options.OvertureReleaseFolder, options.TargetType);
+            if (string.IsNullOrWhiteSpace(targetGlob))
             {
                 throw new FileNotFoundException(
-                    "Could not find downloaded Overture Places GeoParquet files. Load Places first or choose a release folder containing a 'place' subfolder.");
+                    $"Could not find downloaded {options.TargetLabel} GeoParquet files. Load {options.TargetLabel} first or choose a release folder containing a '{options.TargetDatasetType}' subfolder.");
             }
 
             string suffix = GersifyOptions.BuildTimestampSuffix();
@@ -61,11 +72,13 @@ namespace DuckDBGeoparquet.Services
             }
             var inputSignalCounts = await ReadInputSignalCountsAsync(cancellationToken);
 
-            progress?.Report("Checking selected Overture Places files...");
-            var placeColumns = await ReadParquetColumnsAsync(placesGlob, cancellationToken);
-            if (inputSignalCounts.NameCount == 0 &&
+            progress?.Report($"Checking selected {options.TargetLabel} files...");
+            string readOptions = GetReadParquetOptions(options.TargetType);
+            var targetColumns = await ReadParquetColumnsAsync(targetGlob, readOptions, cancellationToken);
+            if (options.TargetType == GersifyTargetType.Places &&
+                inputSignalCounts.NameCount == 0 &&
                 inputSignalCounts.AddressCount > 0 &&
-                !GersSql.HasPlaceAddressColumns(placeColumns))
+                !GersSql.HasPlaceAddressColumns(targetColumns))
             {
                 throw new InvalidOperationException(
                     "The selected Overture Places files do not contain place address fields that GERSify can compare. " +
@@ -73,8 +86,18 @@ namespace DuckDBGeoparquet.Services
                     "Close any map layers or tables using the old Places Parquet files, re-download Places with this add-in version, then choose that release folder again.");
             }
 
-            progress?.Report($"Matching {inputCount:N0} point feature(s) to Overture Places...");
-            await ExecuteNonQueryAsync(GersSql.BuildPlacesCandidateTablesCommand(placesGlob, options, placeColumns), cancellationToken);
+            if (options.TargetType == GersifyTargetType.Addresses && !GersSql.HasAddressDatasetColumns(targetColumns))
+            {
+                throw new InvalidOperationException(
+                    "The selected Overture Addresses files do not contain the address number and street fields that GERSify needs for strict address validation. " +
+                    "Load the Overture Addresses theme with this add-in version, then choose that release folder again.");
+            }
+
+            progress?.Report($"Matching {inputCount:N0} point feature(s) to {options.TargetLabel}...");
+            string candidateSql = options.TargetType == GersifyTargetType.Addresses
+                ? GersSql.BuildAddressesCandidateTablesCommand(targetGlob, options, targetColumns)
+                : GersSql.BuildPlacesCandidateTablesCommand(targetGlob, options, targetColumns);
+            await ExecuteNonQueryAsync(candidateSql, cancellationToken);
 
             progress?.Report("Writing GERSify outputs...");
             await ExecuteNonQueryAsync(
@@ -82,16 +105,22 @@ namespace DuckDBGeoparquet.Services
                     outputCsvPath,
                     candidatesCsvPath,
                     bridgeCsvPath,
-                    string.IsNullOrWhiteSpace(options.DatasetName) ? "user_data" : options.DatasetName),
+                    string.IsNullOrWhiteSpace(options.DatasetName) ? "user_data" : options.DatasetName,
+                    options.TargetTheme,
+                    options.TargetDatasetType),
                 cancellationToken);
 
             int candidateCount = await ExecuteCountAsync(GersSql.CandidateTable, cancellationToken);
             var candidateSignalCounts = await ReadCandidateSignalCountsAsync(cancellationToken);
             int acceptedCount = await ExecuteCountAsync(GersSql.AcceptedTable, cancellationToken);
+            var strategyCounts = await ReadAcceptedStrategyCountsAsync(cancellationToken);
             var acceptedMatches = await ReadAcceptedMatchesAsync(cancellationToken);
 
             return new GersifyResult
             {
+                TargetLabel = options.TargetLabel,
+                TargetTheme = options.TargetTheme,
+                TargetDatasetType = options.TargetDatasetType,
                 InputCount = inputCount,
                 InputNameCount = inputSignalCounts.NameCount,
                 InputAddressCount = inputSignalCounts.AddressCount,
@@ -102,6 +131,7 @@ namespace DuckDBGeoparquet.Services
                 OutputCsvPath = outputCsvPath,
                 CandidateCsvPath = candidatesCsvPath,
                 BridgeCsvPath = bridgeCsvPath,
+                AcceptedStrategyCounts = strategyCounts,
                 AcceptedMatches = acceptedMatches
             };
         }
@@ -142,16 +172,44 @@ namespace DuckDBGeoparquet.Services
                 ReadInt32(reader.GetValue(1)));
         }
 
-        private async Task<IReadOnlyCollection<string>> ReadParquetColumnsAsync(string parquetGlob, CancellationToken cancellationToken)
+        private async Task<Dictionary<string, int>> ReadAcceptedStrategyCountsAsync(CancellationToken cancellationToken)
+        {
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            using var command = _duckDb.Connection.CreateCommand();
+            command.CommandText = $@"
+                SELECT
+                    coalesce(match_strategy, 'unknown') AS match_strategy,
+                    count(*) AS match_count
+                FROM {GersSql.AcceptedTable}
+                GROUP BY match_strategy
+                ORDER BY match_strategy;";
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                string strategy = ReadString(reader, 0);
+                if (!string.IsNullOrWhiteSpace(strategy))
+                {
+                    counts[strategy] = ReadInt32(reader.GetValue(1));
+                }
+            }
+
+            return counts;
+        }
+
+        private async Task<IReadOnlyCollection<string>> ReadParquetColumnsAsync(
+            string parquetGlob,
+            string readParquetOptions,
+            CancellationToken cancellationToken)
         {
             string escapedPath = GeoParquetSql.EscapeSqlLiteral(parquetGlob.Replace('\\', '/'));
             await ExecuteNonQueryAsync($@"
-                CREATE OR REPLACE TABLE gers_place_schema_probe AS
-                SELECT * FROM read_parquet('{escapedPath}', {GersSql.PlacesReadParquetOptions}) LIMIT 0;", cancellationToken);
+                CREATE OR REPLACE TABLE gers_target_schema_probe AS
+                SELECT * FROM read_parquet('{escapedPath}', {readParquetOptions}) LIMIT 0;", cancellationToken);
 
             var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using var command = _duckDb.Connection.CreateCommand();
-            command.CommandText = "DESCRIBE gers_place_schema_probe";
+            command.CommandText = "DESCRIBE gers_target_schema_probe";
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
             {
@@ -212,6 +270,16 @@ namespace DuckDBGeoparquet.Services
             return matches;
         }
 
+        private static string GetReadParquetOptions(GersifyTargetType targetType) =>
+            targetType == GersifyTargetType.Addresses
+                ? GersSql.AddressesReadParquetOptions
+                : GersSql.PlacesReadParquetOptions;
+
+        private static string ResolveTargetParquetGlob(string releaseFolder, GersifyTargetType targetType) =>
+            targetType == GersifyTargetType.Addresses
+                ? ResolveAddressesParquetGlob(releaseFolder)
+                : ResolvePlacesParquetGlob(releaseFolder);
+
         private static string ResolvePlacesParquetGlob(string releaseFolder)
         {
             if (string.IsNullOrWhiteSpace(releaseFolder) || !Directory.Exists(releaseFolder))
@@ -242,6 +310,38 @@ namespace DuckDBGeoparquet.Services
             return nestedPlaceDirectory == null
                 ? null
                 : Path.Combine(nestedPlaceDirectory.FullName, "*.parquet").Replace('\\', '/');
+        }
+
+        private static string ResolveAddressesParquetGlob(string releaseFolder)
+        {
+            if (string.IsNullOrWhiteSpace(releaseFolder) || !Directory.Exists(releaseFolder))
+                return null;
+
+            string[] candidateDirectories =
+            [
+                Path.Combine(releaseFolder, "address"),
+                Path.Combine(releaseFolder, "addresses", "address"),
+                Path.Combine(releaseFolder, "theme=addresses", "type=address")
+            ];
+
+            foreach (string directory in candidateDirectories)
+            {
+                if (Directory.Exists(directory) &&
+                    Directory.EnumerateFiles(directory, "*.parquet", SearchOption.TopDirectoryOnly).Any())
+                {
+                    return Path.Combine(directory, "*.parquet").Replace('\\', '/');
+                }
+            }
+
+            var nestedAddressDirectory = new DirectoryInfo(releaseFolder)
+                .EnumerateDirectories("*", SearchOption.AllDirectories)
+                .FirstOrDefault(directory =>
+                    string.Equals(directory.Name, "address", StringComparison.OrdinalIgnoreCase) &&
+                    directory.EnumerateFiles("*.parquet", SearchOption.TopDirectoryOnly).Any());
+
+            return nestedAddressDirectory == null
+                ? null
+                : Path.Combine(nestedAddressDirectory.FullName, "*.parquet").Replace('\\', '/');
         }
 
         private async Task ExecuteNonQueryAsync(string sql, CancellationToken cancellationToken)

--- a/Services/S3Ingester.cs
+++ b/Services/S3Ingester.cs
@@ -72,7 +72,7 @@ namespace DuckDBGeoparquet.Services
             }
 
             // Determine which columns to project (if any) while always retaining geometry
-            var projectedColumnList = projectedColumns ?? "*";
+            var projectedColumnList = AppendPlaceDerivedColumns(projectedColumns ?? "*", actualS3Type, columnNames);
             bool hasBboxColumn = columnNames != null && columnNames.Any(c => c.Equals(BboxColumn, StringComparison.OrdinalIgnoreCase));
             var projectedColumnsWithoutGeometry = projectedColumns != null
                 ? string.Join(", ", projectedColumns.Split(',').Select(c => c.Trim()).Where(c => !c.Equals("geometry", StringComparison.OrdinalIgnoreCase)))
@@ -86,6 +86,8 @@ namespace DuckDBGeoparquet.Services
                 projectedColumnsWithoutGeometry = "* EXCLUDE(geometry)";
             if (string.IsNullOrWhiteSpace(projectedColumnsWithoutGeometryOrBbox))
                 projectedColumnsWithoutGeometryOrBbox = hasBboxColumn ? "* EXCLUDE(geometry, bbox)" : "* EXCLUDE(geometry)";
+            projectedColumnsWithoutGeometry = AppendPlaceDerivedColumns(projectedColumnsWithoutGeometry, actualS3Type, columnNames);
+            projectedColumnsWithoutGeometryOrBbox = AppendPlaceDerivedColumns(projectedColumnsWithoutGeometryOrBbox, actualS3Type, columnNames);
 
             if (extent != null && !string.IsNullOrEmpty(extentPolygon))
             {
@@ -139,6 +141,19 @@ namespace DuckDBGeoparquet.Services
                         SELECT {projectedColumnList}
                         FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
                         {spatialFilter}";
+        }
+
+        private static string AppendPlaceDerivedColumns(string projection, string actualS3Type, IReadOnlyList<string> columnNames)
+        {
+            if (!string.Equals(actualS3Type, "place", StringComparison.OrdinalIgnoreCase) ||
+                columnNames == null ||
+                !columnNames.Any(c => c.Equals("addresses", StringComparison.OrdinalIgnoreCase)) ||
+                columnNames.Any(c => c.Equals("address_freeform", StringComparison.OrdinalIgnoreCase)))
+            {
+                return projection;
+            }
+
+            return $"{projection}, CAST(addresses[1].freeform AS VARCHAR) AS address_freeform";
         }
     }
 }

--- a/Services/S3Ingester.cs
+++ b/Services/S3Ingester.cs
@@ -147,13 +147,38 @@ namespace DuckDBGeoparquet.Services
         {
             if (!string.Equals(actualS3Type, "place", StringComparison.OrdinalIgnoreCase) ||
                 columnNames == null ||
-                !columnNames.Any(c => c.Equals("addresses", StringComparison.OrdinalIgnoreCase)) ||
-                columnNames.Any(c => c.Equals("address_freeform", StringComparison.OrdinalIgnoreCase)))
+                !columnNames.Any(c => c.Equals("addresses", StringComparison.OrdinalIgnoreCase)))
             {
                 return projection;
             }
 
-            return $"{projection}, CAST(addresses[1].freeform AS VARCHAR) AS address_freeform";
+            var derivedColumns = new List<string>();
+            AddDerivedAddressColumn(derivedColumns, columnNames, "address_freeform",
+                "(SELECT string_agg(CAST(a.freeform AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.freeform IS NOT NULL AND trim(CAST(a.freeform AS VARCHAR)) <> '')");
+            AddDerivedAddressColumn(derivedColumns, columnNames, "address_locality",
+                "(SELECT string_agg(DISTINCT CAST(a.locality AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.locality IS NOT NULL AND trim(CAST(a.locality AS VARCHAR)) <> '')");
+            AddDerivedAddressColumn(derivedColumns, columnNames, "address_region",
+                "(SELECT string_agg(DISTINCT CAST(a.region AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.region IS NOT NULL AND trim(CAST(a.region AS VARCHAR)) <> '')");
+            AddDerivedAddressColumn(derivedColumns, columnNames, "address_postcode",
+                "(SELECT string_agg(DISTINCT left(CAST(a.postcode AS VARCHAR), 5), ' | ') FROM unnest(addresses) AS t(a) WHERE a.postcode IS NOT NULL AND trim(CAST(a.postcode AS VARCHAR)) <> '')");
+            AddDerivedAddressColumn(derivedColumns, columnNames, "address_country",
+                "(SELECT string_agg(DISTINCT CAST(a.country AS VARCHAR), ' | ') FROM unnest(addresses) AS t(a) WHERE a.country IS NOT NULL AND trim(CAST(a.country AS VARCHAR)) <> '')");
+
+            return derivedColumns.Count == 0
+                ? projection
+                : $"{projection}, {string.Join(", ", derivedColumns)}";
+        }
+
+        private static void AddDerivedAddressColumn(
+            ICollection<string> derivedColumns,
+            IReadOnlyList<string> columnNames,
+            string columnName,
+            string expression)
+        {
+            if (columnNames.Any(c => c.Equals(columnName, StringComparison.OrdinalIgnoreCase)))
+                return;
+
+            derivedColumns.Add($"{expression} AS {columnName}");
         }
     }
 }

--- a/Services/S3Ingester.cs
+++ b/Services/S3Ingester.cs
@@ -20,6 +20,7 @@ namespace DuckDBGeoparquet.Services
     {
         private const string BboxColumn = "bbox";
         private const string GeometryColumn = "geometry";
+        public const string S3ReadParquetOptions = "filename=true, hive_partitioning=1, union_by_name=1";
 
         /// <summary>
         /// Build a projection list that drops known heavy optional columns for the given dataset type.
@@ -105,7 +106,7 @@ namespace DuckDBGeoparquet.Services
                                     THEN ST_Intersection(geometry, {extentPolygon})
                                     ELSE NULL
                                 END AS clipped_geometry
-                            FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
+                            FROM read_parquet('{s3Path}', {S3ReadParquetOptions})
                             {spatialFilter}
                         )
                         SELECT
@@ -132,14 +133,14 @@ namespace DuckDBGeoparquet.Services
                                 THEN ST_Intersection(geometry, {extentPolygon})
                                 ELSE NULL
                             END as geometry
-                        FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
+                        FROM read_parquet('{s3Path}', {S3ReadParquetOptions})
                         {spatialFilter}";
             }
 
             return $@"
                         CREATE OR REPLACE TABLE current_table AS
                         SELECT {projectedColumnList}
-                        FROM read_parquet('{s3Path}', filename=true, hive_partitioning=1)
+                        FROM read_parquet('{s3Path}', {S3ReadParquetOptions})
                         {spatialFilter}";
         }
 

--- a/Views/GersifyDockpane.xaml
+++ b/Views/GersifyDockpane.xaml
@@ -51,7 +51,7 @@
                         </Grid>
 
                         <TextBlock Text="Field Mapping" FontWeight="SemiBold" Margin="0,4,0,4"
-                                   ToolTipService.ToolTip="Map your layer fields to the values used for matching. Unique ID and Name are required; address fields improve confidence when present."/>
+                                   ToolTipService.ToolTip="Map your layer fields to the values used for matching. Unique ID is required. Use either a place name, address fields, or both."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="120"/>
@@ -64,30 +64,69 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Unique ID" VerticalAlignment="Center" Margin="0,0,8,6"
                                        ToolTipService.ToolTip="Your stable record key. The bridge CSV uses this as record_id and maps it to the matched GERS ID."/>
                             <ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedIdField}" Margin="0,0,0,6"
                                       ToolTipService.ToolTip="Pick a field that uniquely identifies each input feature, such as ID, OBJECTID, GlobalID, or your business key."/>
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"
-                                       ToolTipService.ToolTip="The place or business name used for string similarity against Overture Places."/>
-                            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedNameField}" Margin="0,0,0,6"
-                                      ToolTipService.ToolTip="Required. Choose the field containing the best human-readable place name."/>
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"
-                                       ToolTipService.ToolTip="Optional street address context. When present, it can raise or lower the final match confidence."/>
+                                       ToolTipService.ToolTip="Optional place or business name used for string similarity against Overture Places."/>
+                            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedNameField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Choose this when your input has place or business names. Leave blank for address-point datasets."/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Full Address" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Optional complete street address. If blank, the tool builds one from the parsed address fields below."/>
                             <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedAddressField}" Margin="0,0,0,6"
-                                      ToolTipService.ToolTip="Optional. Leave blank if your layer does not have an address field."/>
-                            <TextBlock Grid.Row="3" Grid.Column="0" Text="City" VerticalAlignment="Center" Margin="0,0,8,6"
+                                      ToolTipService.ToolTip="Use this if your table already has a complete address field. Leave blank when address components are split across fields."/>
+
+                            <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Text="Parsed Address Fields" FontWeight="SemiBold" Margin="0,4,0,4"
+                                       ToolTipService.ToolTip="Use these when your address data is parsed into pieces such as ADDRESS_NUMBER, street name, type, unit, ZIP city, and ZIP5."/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Number" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Street number, such as ADDRESS_NUMBER."/>
+                            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStreetNumberField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional. Used with the other parsed fields to build a matchable address string."/>
+                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Fraction" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Fractional address number, such as ADDRESS_FRACTION for 1/2 addresses."/>
+                            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStreetFractionField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional. Leave blank unless your data stores fractional address numbers."/>
+                            <TextBlock Grid.Row="6" Grid.Column="0" Text="Prefix" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Street directional prefix, such as N, S, E, or W."/>
+                            <ComboBox Grid.Row="6" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStreetPrefixField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional street prefix/directional field."/>
+                            <TextBlock Grid.Row="7" Grid.Column="0" Text="Street" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Street name field."/>
+                            <ComboBox Grid.Row="7" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStreetNameField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Pick the street name field if your address is parsed. This pairs with Number and Type."/>
+                            <TextBlock Grid.Row="8" Grid.Column="0" Text="Type" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Street type, such as ST, AVE, RD, or BLVD."/>
+                            <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStreetTypeField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional street type field."/>
+                            <TextBlock Grid.Row="9" Grid.Column="0" Text="Suffix" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Street suffix or post-directional, such as NE or SW."/>
+                            <ComboBox Grid.Row="9" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStreetSuffixField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional street suffix/post-directional field."/>
+                            <TextBlock Grid.Row="10" Grid.Column="0" Text="Unit" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Unit, suite, apartment, or address unit field."/>
+                            <ComboBox Grid.Row="10" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedUnitField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional unit field. It is included in the address text when present."/>
+                            <TextBlock Grid.Row="11" Grid.Column="0" Text="City" VerticalAlignment="Center" Margin="0,0,8,6"
                                        ToolTipService.ToolTip="Optional locality context included in the address similarity text."/>
-                            <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedCityField}" Margin="0,0,0,6"
+                            <ComboBox Grid.Row="11" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedCityField}" Margin="0,0,0,6"
                                       ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
-                            <TextBlock Grid.Row="4" Grid.Column="0" Text="State" VerticalAlignment="Center" Margin="0,0,8,6"
+                            <TextBlock Grid.Row="12" Grid.Column="0" Text="State" VerticalAlignment="Center" Margin="0,0,8,6"
                                        ToolTipService.ToolTip="Optional region context included in the address similarity text."/>
-                            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStateField}" Margin="0,0,0,6"
+                            <ComboBox Grid.Row="12" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStateField}" Margin="0,0,0,6"
                                       ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
-                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Postcode" VerticalAlignment="Center" Margin="0,0,8,0"
+                            <TextBlock Grid.Row="13" Grid.Column="0" Text="Postcode" VerticalAlignment="Center" Margin="0,0,8,0"
                                        ToolTipService.ToolTip="Optional postal code context included in the address similarity text."/>
-                            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedPostcodeField}"
+                            <ComboBox Grid.Row="13" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedPostcodeField}"
                                       ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
                         </Grid>
 

--- a/Views/GersifyDockpane.xaml
+++ b/Views/GersifyDockpane.xaml
@@ -138,6 +138,25 @@
                                       ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
                         </Grid>
 
+                        <TextBlock Text="Mapping Preview" FontWeight="SemiBold" Margin="0,4,0,4"
+                                   ToolTipService.ToolTip="Shows the fields GERSify will export plus sample address and postcode values from the selected layer."/>
+                        <TextBox Text="{Binding FieldMappingPreviewText, Mode=OneWay}"
+                                 IsReadOnly="True"
+                                 TextWrapping="Wrap"
+                                 MinHeight="120"
+                                 MaxHeight="220"
+                                 VerticalScrollBarVisibility="Auto"
+                                 FontFamily="Consolas"
+                                 Margin="0,0,0,6"
+                                 Background="{DynamicResource Esri_DialogClientAreaBackgroundBrush}"
+                                 Foreground="{DynamicResource Esri_TextControlBrush}"
+                                 ToolTipService.ToolTip="Preview the resolved source fields and a few built output values before running GERSify."/>
+                        <TextBlock Text="{Binding FieldMappingWarningText}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,8"
+                                   Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"
+                                   ToolTipService.ToolTip="Warnings are based on selected fields and a small sample of source rows."/>
+
                         <TextBlock Text="Overture Data" FontWeight="SemiBold" Margin="0,6,0,4"
                                    ToolTipService.ToolTip="Folder containing downloaded Overture data for one release. It must include the selected match target."/>
                         <Grid Margin="0,0,0,8">

--- a/Views/GersifyDockpane.xaml
+++ b/Views/GersifyDockpane.xaml
@@ -188,11 +188,11 @@
                             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding NameSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Raise this for conservative matching; lower it when names vary across systems."/>
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"
-                                       ToolTipService.ToolTip="Minimum address similarity when both your data and Overture have address text. Blank Overture addresses do not block a match."/>
+                                       ToolTipService.ToolTip="Minimum address similarity when both your data and Overture have address text. The tool compares street-only text and full city/state/ZIP context, using the stronger score."/>
                             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AddressSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Raise this when address fields are clean; lower it when addresses are partial or inconsistently formatted."/>
                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Score" VerticalAlignment="Center" Margin="0,0,8,0"
-                                       ToolTipService.ToolTip="Minimum combined score for automatic acceptance. The score blends name, optional address, and distance."/>
+                                       ToolTipService.ToolTip="Minimum combined score for automatic acceptance. Address-only inputs can also accept very close nearby places when Overture lacks comparable address text."/>
                             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AcceptScoreThreshold, UpdateSourceTrigger=PropertyChanged}"
                                      ToolTipService.ToolTip="Accepted matches get written to gers_id fields and bridge CSV output. Other candidates remain in the review CSV."/>
                         </Grid>

--- a/Views/GersifyDockpane.xaml
+++ b/Views/GersifyDockpane.xaml
@@ -25,10 +25,12 @@
         </Grid.RowDefinitions>
 
         <TabControl Grid.Row="0">
-            <TabItem Header="GERSify Places">
+            <TabItem Header="GERSify Places"
+                     ToolTipService.ToolTip="Match your point layer to downloaded Overture Places. The tool adds matched GERS IDs to a new output layer and writes review/bridge CSVs.">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="0,8,0,8">
-                        <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                        <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"
+                                   ToolTipService.ToolTip="Choose the point feature layer that contains the places, businesses, or facilities you want to match."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
@@ -38,15 +40,18 @@
                                       ItemsSource="{Binding InputLayers}"
                                       SelectedItem="{Binding SelectedInputLayer}"
                                       DisplayMemberPath="Name"
-                                      Margin="0,0,8,0"/>
+                                      Margin="0,0,8,0"
+                                      ToolTipService.ToolTip="The source point layer. Each feature is exported temporarily, matched in DuckDB, then written to a new GERSified output layer."/>
                             <Button Grid.Column="1"
                                     Content="Refresh"
                                     Command="{Binding RefreshLayersCommand}"
                                     Width="82"
-                                    Style="{DynamicResource Esri_Button}"/>
+                                    Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Reload the list of feature layers from the active map."/>
                         </Grid>
 
-                        <TextBlock Text="Field Mapping" FontWeight="SemiBold" Margin="0,4,0,4"/>
+                        <TextBlock Text="Field Mapping" FontWeight="SemiBold" Margin="0,4,0,4"
+                                   ToolTipService.ToolTip="Map your layer fields to the values used for matching. Unique ID and Name are required; address fields improve confidence when present."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="120"/>
@@ -60,49 +65,70 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Unique ID" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedIdField}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedNameField}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedAddressField}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="3" Grid.Column="0" Text="City" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedCityField}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="4" Grid.Column="0" Text="State" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStateField}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Postcode" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedPostcodeField}"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Unique ID" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Your stable record key. The bridge CSV uses this as record_id and maps it to the matched GERS ID."/>
+                            <ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedIdField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Pick a field that uniquely identifies each input feature, such as ID, OBJECTID, GlobalID, or your business key."/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="The place or business name used for string similarity against Overture Places."/>
+                            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedNameField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Required. Choose the field containing the best human-readable place name."/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Optional street address context. When present, it can raise or lower the final match confidence."/>
+                            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedAddressField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional. Leave blank if your layer does not have an address field."/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="City" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Optional locality context included in the address similarity text."/>
+                            <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedCityField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="State" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Optional region context included in the address similarity text."/>
+                            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStateField}" Margin="0,0,0,6"
+                                      ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
+                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Postcode" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       ToolTipService.ToolTip="Optional postal code context included in the address similarity text."/>
+                            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedPostcodeField}"
+                                      ToolTipService.ToolTip="Optional. Used only to improve address/context matching."/>
                         </Grid>
 
-                        <TextBlock Text="Overture Data" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <TextBlock Text="Overture Data" FontWeight="SemiBold" Margin="0,6,0,4"
+                                   ToolTipService.ToolTip="Folder containing downloaded Overture data for one release. For this MVP, it must include Places data."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox Grid.Column="0" Text="{Binding ReleaseFolderPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
-                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseReleaseFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"/>
+                            <TextBox Grid.Column="0" Text="{Binding ReleaseFolderPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"
+                                     ToolTipService.ToolTip="Defaults to the newest loaded Overture release under the project. Choose another release folder if needed."/>
+                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseReleaseFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Choose the Overture release folder that contains the Places GeoParquet files."/>
                         </Grid>
 
-                        <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"
+                                   ToolTipService.ToolTip="The tool writes a new point layer, a candidate review CSV, and a bridge CSV mapping your record IDs to GERS IDs."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox Grid.Column="0" Text="{Binding OutputFolder, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
-                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseOutputFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"/>
+                            <TextBox Grid.Column="0" Text="{Binding OutputFolder, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"
+                                     ToolTipService.ToolTip="Folder for the generated file geodatabase and CSV outputs. Defaults under OvertureProAddinData\\GERSify."/>
+                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseOutputFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Choose where the output layer database and CSV files will be written."/>
                         </Grid>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="120"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="Dataset Name" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <TextBox Grid.Column="1" Text="{Binding DatasetName, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Grid.Column="0" Text="Dataset Name" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       ToolTipService.ToolTip="Label written to the bridge CSV dataset column so downstream users know which source data was matched."/>
+                            <TextBox Grid.Column="1" Text="{Binding DatasetName, UpdateSourceTrigger=PropertyChanged}"
+                                     ToolTipService.ToolTip="Use a short source name, such as your department, system, or feature class name."/>
                         </Grid>
 
-                        <TextBlock Text="Thresholds" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <TextBlock Text="Thresholds" FontWeight="SemiBold" Margin="0,6,0,4"
+                                   ToolTipService.ToolTip="Controls how strict automatic acceptance is. Lower values produce more matches; higher values produce fewer, safer matches."/>
                         <Grid Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="120"/>
@@ -114,30 +140,41 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Distance m" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding MaxDistanceMeters, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding NameSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AddressSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Score" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AcceptScoreThreshold, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Distance m" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Maximum distance from your point to an Overture Place candidate. Start with 75 meters for address-quality points."/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding MaxDistanceMeters, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
+                                     ToolTipService.ToolTip="Candidates farther than this distance are ignored before name/address scoring."/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Minimum name similarity for an automatic match. 1.0 is exact; 0.86 allows minor spelling and formatting differences."/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding NameSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
+                                     ToolTipService.ToolTip="Raise this for conservative matching; lower it when names vary across systems."/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Minimum address similarity when both your data and Overture have address text. Blank Overture addresses do not block a match."/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AddressSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
+                                     ToolTipService.ToolTip="Raise this when address fields are clean; lower it when addresses are partial or inconsistently formatted."/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Score" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       ToolTipService.ToolTip="Minimum combined score for automatic acceptance. The score blends name, optional address, and distance."/>
+                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AcceptScoreThreshold, UpdateSourceTrigger=PropertyChanged}"
+                                     ToolTipService.ToolTip="Accepted matches get written to gers_id fields and bridge CSV output. Other candidates remain in the review CSV."/>
                         </Grid>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                             <Button Content="Run GERSify"
                                     Command="{Binding RunGersifyCommand}"
                                     Width="110"
-                                    Style="{DynamicResource Esri_Button}"/>
+                                    Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Run matching. Creates a new point feature class with gers_id and score fields, plus candidate review and bridge CSV files."/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>
 
-            <TabItem Header="Trace Sources">
+            <TabItem Header="Trace Sources"
+                     ToolTipService.ToolTip="Look up source dataset record IDs for existing GERS IDs using Overture bridge files. Useful for escalation and source-data maintenance.">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="0,8,0,8">
-                        <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                        <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"
+                                   ToolTipService.ToolTip="Choose a layer that already has GERS IDs, such as a GERSified output layer or an Overture-derived layer."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
@@ -147,23 +184,28 @@
                                       ItemsSource="{Binding TraceLayers}"
                                       SelectedItem="{Binding SelectedTraceLayer}"
                                       DisplayMemberPath="Name"
-                                      Margin="0,0,8,0"/>
+                                      Margin="0,0,8,0"
+                                      ToolTipService.ToolTip="The tool exports the selected GERS ID field, queries bridge files, then writes a source lookup table."/>
                             <Button Grid.Column="1"
                                     Content="Refresh"
                                     Command="{Binding RefreshLayersCommand}"
                                     Width="82"
-                                    Style="{DynamicResource Esri_Button}"/>
+                                    Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Reload the list of feature layers from the active map."/>
                         </Grid>
                         <Grid Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="120"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="GERS ID Field" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <ComboBox Grid.Column="1" ItemsSource="{Binding TraceFields}" SelectedItem="{Binding SelectedTraceGersIdField}"/>
+                            <TextBlock Grid.Column="0" Text="GERS ID Field" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       ToolTipService.ToolTip="Field containing Overture/GERS IDs to trace back to source records."/>
+                            <ComboBox Grid.Column="1" ItemsSource="{Binding TraceFields}" SelectedItem="{Binding SelectedTraceGersIdField}"
+                                      ToolTipService.ToolTip="Usually gers_id, overture_id, or id depending on the source layer."/>
                         </Grid>
 
-                        <TextBlock Text="Bridge Files" FontWeight="SemiBold" Margin="0,4,0,4"/>
+                        <TextBlock Text="Bridge Files" FontWeight="SemiBold" Margin="0,4,0,4"
+                                   ToolTipService.ToolTip="Bridge files map GERS IDs back to source dataset record IDs for a specific Overture release, theme, and type."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="120"/>
@@ -175,31 +217,43 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Root" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding BridgeRoot, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Release" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BridgeRelease, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Theme" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BridgeTheme, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Type" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BridgeType, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Root" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Bridge file storage root. Azure HTTP is the default; S3 can also be used when DuckDB has access."/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding BridgeRoot, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
+                                     ToolTipService.ToolTip="Default: https://overturemapswestus2.blob.core.windows.net/bridgefiles"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Release" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Overture release containing the bridge files to query."/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BridgeRelease, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
+                                     ToolTipService.ToolTip="Use the same release as the Overture data you matched against when possible."/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Theme" VerticalAlignment="Center" Margin="0,0,8,6"
+                                       ToolTipService.ToolTip="Bridge theme to query. For Places GERSification, use places."/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BridgeTheme, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
+                                     ToolTipService.ToolTip="Examples include places, buildings, transportation, and divisions when bridge coverage exists."/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Type" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       ToolTipService.ToolTip="Bridge type to query. For Places GERSification, use place."/>
+                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BridgeType, UpdateSourceTrigger=PropertyChanged}"
+                                     ToolTipService.ToolTip="Examples include place, building, segment, connector, division_area, and division_boundary when bridge coverage exists."/>
                         </Grid>
 
-                        <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"
+                                   ToolTipService.ToolTip="Trace Sources writes a CSV table with gers_id, dataset, record_id, update_time, theme, type, and OSM URLs where possible."/>
                         <Grid Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox Grid.Column="0" Text="{Binding OutputFolder, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
-                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseOutputFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"/>
+                            <TextBox Grid.Column="0" Text="{Binding OutputFolder, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"
+                                     ToolTipService.ToolTip="Folder where the source lookup CSV will be written and added to the active map as a standalone table."/>
+                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseOutputFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Choose where the source lookup CSV will be written."/>
                         </Grid>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                             <Button Content="Trace Sources"
                                     Command="{Binding RunTraceSourcesCommand}"
                                     Width="110"
-                                    Style="{DynamicResource Esri_Button}"/>
+                                    Style="{DynamicResource Esri_Button}"
+                                    ToolTipService.ToolTip="Query bridge files for the selected GERS IDs and add the resulting source lookup CSV to the map."/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>

--- a/Views/GersifyDockpane.xaml
+++ b/Views/GersifyDockpane.xaml
@@ -25,8 +25,8 @@
         </Grid.RowDefinitions>
 
         <TabControl Grid.Row="0">
-            <TabItem Header="GERSify Places"
-                     ToolTipService.ToolTip="Match your point layer to downloaded Overture Places. The tool adds matched GERS IDs to a new output layer and writes review/bridge CSVs.">
+            <TabItem Header="GERSify Data"
+                     ToolTipService.ToolTip="Match your point layer to downloaded Overture Addresses or Places. The tool adds matched GERS IDs to a new output layer and writes review/bridge CSVs.">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="0,8,0,8">
                         <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"
@@ -49,6 +49,14 @@
                                     Style="{DynamicResource Esri_Button}"
                                     ToolTipService.ToolTip="Reload the list of feature layers from the active map."/>
                         </Grid>
+
+                        <TextBlock Text="Match Target" FontWeight="SemiBold" Margin="0,4,0,4"
+                                   ToolTipService.ToolTip="Choose Addresses for strict 1:1 address validation, or Places for POI/place enrichment."/>
+                        <ComboBox ItemsSource="{Binding GersifyTargets}"
+                                  SelectedItem="{Binding SelectedGersifyTarget}"
+                                  DisplayMemberPath="Name"
+                                  Margin="0,0,0,8"
+                                  ToolTipService.ToolTip="Addresses compares your address points to Overture Addresses. Places compares names and addresses to Overture Places."/>
 
                         <TextBlock Text="Field Mapping" FontWeight="SemiBold" Margin="0,4,0,4"
                                    ToolTipService.ToolTip="Map your layer fields to the values used for matching. Unique ID is required. Use either a place name, address fields, or both."/>
@@ -131,7 +139,7 @@
                         </Grid>
 
                         <TextBlock Text="Overture Data" FontWeight="SemiBold" Margin="0,6,0,4"
-                                   ToolTipService.ToolTip="Folder containing downloaded Overture data for one release. For this MVP, it must include Places data."/>
+                                   ToolTipService.ToolTip="Folder containing downloaded Overture data for one release. It must include the selected match target."/>
                         <Grid Margin="0,0,0,8">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
@@ -140,7 +148,7 @@
                             <TextBox Grid.Column="0" Text="{Binding ReleaseFolderPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"
                                      ToolTipService.ToolTip="Defaults to the newest loaded Overture release under the project. Choose another release folder if needed."/>
                             <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseReleaseFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"
-                                    ToolTipService.ToolTip="Choose the Overture release folder that contains the Places GeoParquet files."/>
+                                    ToolTipService.ToolTip="Choose the Overture release folder that contains the selected target GeoParquet files."/>
                         </Grid>
 
                         <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"
@@ -178,9 +186,10 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Distance m" VerticalAlignment="Center" Margin="0,0,8,6"
-                                       ToolTipService.ToolTip="Maximum distance from your point to an Overture Place candidate. Start with 75 meters for address-quality points."/>
+                                       ToolTipService.ToolTip="Maximum distance from your point to an Overture candidate. Start with 75 meters for address-quality points."/>
                             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding MaxDistanceMeters, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Candidates farther than this distance are ignored before name/address scoring."/>
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"
@@ -192,9 +201,13 @@
                             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AddressSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Raise this when address fields are clean; lower it when addresses are partial or inconsistently formatted."/>
                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Score" VerticalAlignment="Center" Margin="0,0,8,0"
-                                       ToolTipService.ToolTip="Minimum combined score for automatic acceptance. Address-only inputs can also accept very close nearby places when Overture lacks comparable address text."/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AcceptScoreThreshold, UpdateSourceTrigger=PropertyChanged}"
+                                       ToolTipService.ToolTip="Minimum combined score for automatic acceptance."/>
+                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AcceptScoreThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Accepted matches get written to gers_id fields and bridge CSV output. Other candidates remain in the review CSV."/>
+                            <CheckBox Grid.Row="4" Grid.Column="1"
+                                      Content="Allow nearby-only fallback"
+                                      IsChecked="{Binding AllowNearbyOnlyMatches}"
+                                      ToolTipService.ToolTip="Places only. Allows very close candidates when neither name nor address similarity can be scored. Leave off for strict address validation."/>
                         </Grid>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
@@ -265,11 +278,11 @@
                             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BridgeRelease, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Use the same release as the Overture data you matched against when possible."/>
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Theme" VerticalAlignment="Center" Margin="0,0,8,6"
-                                       ToolTipService.ToolTip="Bridge theme to query. For Places GERSification, use places."/>
+                                       ToolTipService.ToolTip="Bridge theme to query. Use addresses for address validation outputs or places for Places enrichment outputs."/>
                             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BridgeTheme, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"
                                      ToolTipService.ToolTip="Examples include places, buildings, transportation, and divisions when bridge coverage exists."/>
                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Type" VerticalAlignment="Center" Margin="0,0,8,0"
-                                       ToolTipService.ToolTip="Bridge type to query. For Places GERSification, use place."/>
+                                       ToolTipService.ToolTip="Bridge type to query. Use address for address validation outputs or place for Places enrichment outputs."/>
                             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BridgeType, UpdateSourceTrigger=PropertyChanged}"
                                      ToolTipService.ToolTip="Examples include place, building, segment, connector, division_area, and division_boundary when bridge coverage exists."/>
                         </Grid>

--- a/Views/GersifyDockpane.xaml
+++ b/Views/GersifyDockpane.xaml
@@ -1,0 +1,225 @@
+<UserControl x:Class="DuckDBGeoparquet.Views.GersifyDockpaneView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"
+             xmlns:local="clr-namespace:DuckDBGeoparquet.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="680"
+             d:DesignWidth="430"
+             d:DataContext="{d:DesignInstance local:GersifyDockpaneViewModel}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <extensions:DesignOnlyResourceDictionary Source="pack://application:,,,/ArcGIS.Desktop.Framework;component\Themes\Default.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid Margin="16,12,16,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="120"/>
+        </Grid.RowDefinitions>
+
+        <TabControl Grid.Row="0">
+            <TabItem Header="GERSify Places">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,8,0,8">
+                        <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <ComboBox Grid.Column="0"
+                                      ItemsSource="{Binding InputLayers}"
+                                      SelectedItem="{Binding SelectedInputLayer}"
+                                      DisplayMemberPath="Name"
+                                      Margin="0,0,8,0"/>
+                            <Button Grid.Column="1"
+                                    Content="Refresh"
+                                    Command="{Binding RefreshLayersCommand}"
+                                    Width="82"
+                                    Style="{DynamicResource Esri_Button}"/>
+                        </Grid>
+
+                        <TextBlock Text="Field Mapping" FontWeight="SemiBold" Margin="0,4,0,4"/>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Unique ID" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedIdField}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding InputFields}" SelectedItem="{Binding SelectedNameField}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedAddressField}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="City" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedCityField}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="State" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedStateField}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Postcode" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding OptionalInputFields}" SelectedItem="{Binding SelectedPostcodeField}"/>
+                        </Grid>
+
+                        <TextBlock Text="Overture Data" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Grid.Column="0" Text="{Binding ReleaseFolderPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
+                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseReleaseFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"/>
+                        </Grid>
+
+                        <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Grid.Column="0" Text="{Binding OutputFolder, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
+                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseOutputFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="Dataset Name" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Grid.Column="1" Text="{Binding DatasetName, UpdateSourceTrigger=PropertyChanged}"/>
+                        </Grid>
+
+                        <TextBlock Text="Thresholds" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <Grid Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Distance m" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding MaxDistanceMeters, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding NameSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AddressSimilarityThreshold, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Score" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AcceptScoreThreshold, UpdateSourceTrigger=PropertyChanged}"/>
+                        </Grid>
+
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Content="Run GERSify"
+                                    Command="{Binding RunGersifyCommand}"
+                                    Width="110"
+                                    Style="{DynamicResource Esri_Button}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <TabItem Header="Trace Sources">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,8,0,8">
+                        <TextBlock Text="Input Layer" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <ComboBox Grid.Column="0"
+                                      ItemsSource="{Binding TraceLayers}"
+                                      SelectedItem="{Binding SelectedTraceLayer}"
+                                      DisplayMemberPath="Name"
+                                      Margin="0,0,8,0"/>
+                            <Button Grid.Column="1"
+                                    Content="Refresh"
+                                    Command="{Binding RefreshLayersCommand}"
+                                    Width="82"
+                                    Style="{DynamicResource Esri_Button}"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="GERS ID Field" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <ComboBox Grid.Column="1" ItemsSource="{Binding TraceFields}" SelectedItem="{Binding SelectedTraceGersIdField}"/>
+                        </Grid>
+
+                        <TextBlock Text="Bridge Files" FontWeight="SemiBold" Margin="0,4,0,4"/>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Root" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding BridgeRoot, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Release" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BridgeRelease, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Theme" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BridgeTheme, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Type" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BridgeType, UpdateSourceTrigger=PropertyChanged}"/>
+                        </Grid>
+
+                        <TextBlock Text="Output" FontWeight="SemiBold" Margin="0,6,0,4"/>
+                        <Grid Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Grid.Column="0" Text="{Binding OutputFolder, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
+                            <Button Grid.Column="1" Content="Browse..." Command="{Binding BrowseOutputFolderCommand}" Width="82" Style="{DynamicResource Esri_Button}"/>
+                        </Grid>
+
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Content="Trace Sources"
+                                    Command="{Binding RunTraceSourcesCommand}"
+                                    Width="110"
+                                    Style="{DynamicResource Esri_Button}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+        </TabControl>
+
+        <TextBlock Grid.Row="1"
+                   Text="{Binding StatusText}"
+                   TextWrapping="Wrap"
+                   Foreground="{DynamicResource Esri_TextStyleSubduedBrush}"
+                   Margin="0,8,0,6"/>
+
+        <TextBox Grid.Row="2"
+                 Text="{Binding LogText, Mode=OneWay}"
+                 IsReadOnly="True"
+                 TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto"
+                 FontFamily="Consolas"
+                 Background="{DynamicResource Esri_DialogClientAreaBackgroundBrush}"
+                 Foreground="{DynamicResource Esri_TextControlBrush}"
+                 TextChanged="LogTextBox_TextChanged"/>
+    </Grid>
+</UserControl>

--- a/Views/GersifyDockpane.xaml.cs
+++ b/Views/GersifyDockpane.xaml.cs
@@ -1,0 +1,20 @@
+using System.Windows.Controls;
+
+namespace DuckDBGeoparquet.Views
+{
+    public partial class GersifyDockpaneView : UserControl
+    {
+        public GersifyDockpaneView()
+        {
+            InitializeComponent();
+        }
+
+        private void LogTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is TextBox textBox)
+            {
+                textBox.ScrollToEnd();
+            }
+        }
+    }
+}

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -524,7 +524,7 @@ namespace DuckDBGeoparquet.Views
                 }, progress);
 
                 StatusText = "Adding GERSify outputs to the map...";
-                string layerName = $"GERSified_{MfcUtility.SanitizeFileName(SelectedInputLayer.Name)}";
+                string layerName = $"GERSified_{SelectedInputLayer.Name}";
                 result.OutputFeatureClassPath = await WriteGersifiedFeatureClassAsync(result.OutputCsvPath, OutputFolder, layerName);
                 await TryAddStandaloneTableAsync(result.CandidateCsvPath);
                 await TryAddStandaloneTableAsync(result.BridgeCsvPath);
@@ -746,9 +746,7 @@ namespace DuckDBGeoparquet.Views
                 }
             }
 
-            string featureClassName = MfcUtility.SanitizeFileName(layerName);
-            if (featureClassName.Length > 50)
-                featureClassName = featureClassName[..50];
+            string featureClassName = ArcGisNameSanitizer.ToFileGeodatabaseFeatureClassName(layerName);
 
             string outputFeatureClassPath = Path.Combine(gdbPath, featureClassName);
             var result = await Geoprocessing.ExecuteToolAsync(

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -57,6 +57,8 @@ namespace DuckDBGeoparquet.Views
         private string _bridgeType = "place";
         private string _statusText = "Ready.";
         private string _logText = string.Empty;
+        private string _fieldMappingPreviewText = "Choose an input layer to preview the resolved field mapping.";
+        private string _fieldMappingWarningText = string.Empty;
 
         protected GersifyDockpaneViewModel()
         {
@@ -153,7 +155,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedIdField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -163,7 +168,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedNameField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -173,7 +181,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedAddressField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -183,7 +194,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStreetNumberField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -193,7 +207,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStreetFractionField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -203,7 +220,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStreetPrefixField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -213,7 +233,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStreetNameField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -223,7 +246,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStreetTypeField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -233,7 +259,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStreetSuffixField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -243,7 +272,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedUnitField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -253,7 +285,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedCityField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -263,7 +298,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedStateField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -273,7 +311,10 @@ namespace DuckDBGeoparquet.Views
             set
             {
                 if (SetProperty(ref _selectedPostcodeField, value))
+                {
+                    _ = RefreshFieldMappingPreviewAsync();
                     RaiseCommandStatesChanged();
+                }
             }
         }
 
@@ -389,6 +430,18 @@ namespace DuckDBGeoparquet.Views
             set => SetProperty(ref _logText, value);
         }
 
+        public string FieldMappingPreviewText
+        {
+            get => _fieldMappingPreviewText;
+            set => SetProperty(ref _fieldMappingPreviewText, value);
+        }
+
+        public string FieldMappingWarningText
+        {
+            get => _fieldMappingWarningText;
+            set => SetProperty(ref _fieldMappingWarningText, value);
+        }
+
         public ICommand RefreshLayersCommand { get; }
         public ICommand BrowseReleaseFolderCommand { get; }
         public ICommand BrowseOutputFolderCommand { get; }
@@ -456,6 +509,64 @@ namespace DuckDBGeoparquet.Views
             SelectedCityField = SelectField(fields, "address_zipcity", "city", "locality", "town", "scity");
             SelectedStateField = SelectField(fields, "address_state", "state", "region", "province", "state2");
             SelectedPostcodeField = SelectField(fields, "address_zip5", "postcode", "postal_code", "zip", "zip5", "address_zip4");
+            _ = RefreshFieldMappingPreviewAsync();
+        }
+
+        private async Task RefreshFieldMappingPreviewAsync()
+        {
+            var layerItem = SelectedInputLayer;
+            if (layerItem?.Layer == null)
+            {
+                FieldMappingPreviewText = "Choose an input layer to preview the resolved field mapping.";
+                FieldMappingWarningText = string.Empty;
+                return;
+            }
+
+            string idField = SelectedIdField;
+            string nameField = SelectedNameField;
+            string addressField = SelectedAddressField;
+            string streetNumberField = SelectedStreetNumberField;
+            string streetFractionField = SelectedStreetFractionField;
+            string streetPrefixField = SelectedStreetPrefixField;
+            string streetNameField = SelectedStreetNameField;
+            string streetTypeField = SelectedStreetTypeField;
+            string streetSuffixField = SelectedStreetSuffixField;
+            string unitField = SelectedUnitField;
+            string cityField = SelectedCityField;
+            string stateField = SelectedStateField;
+            string postcodeField = SelectedPostcodeField;
+            var inputFields = InputFields.ToList();
+
+            try
+            {
+                var preview = await QueuedTask.Run(() => BuildFieldMappingPreview(
+                    layerItem.Layer,
+                    inputFields,
+                    idField,
+                    nameField,
+                    addressField,
+                    streetNumberField,
+                    streetFractionField,
+                    streetPrefixField,
+                    streetNameField,
+                    streetTypeField,
+                    streetSuffixField,
+                    unitField,
+                    cityField,
+                    stateField,
+                    postcodeField));
+
+                if (ReferenceEquals(layerItem, SelectedInputLayer))
+                {
+                    FieldMappingPreviewText = preview.PreviewText;
+                    FieldMappingWarningText = preview.WarningText;
+                }
+            }
+            catch (Exception ex)
+            {
+                FieldMappingPreviewText = "Could not preview field mapping.";
+                FieldMappingWarningText = ex.Message;
+            }
         }
 
         private async Task RefreshTraceFieldsAsync(LayerSelectionItem layerItem)
@@ -486,6 +597,119 @@ namespace DuckDBGeoparquet.Views
                     .ToList();
             });
         }
+
+        private static FieldMappingPreview BuildFieldMappingPreview(
+            FeatureLayer layer,
+            IReadOnlyCollection<string> inputFields,
+            string idField,
+            string nameField,
+            string addressField,
+            string streetNumberField,
+            string streetFractionField,
+            string streetPrefixField,
+            string streetNameField,
+            string streetTypeField,
+            string streetSuffixField,
+            string unitField,
+            string cityField,
+            string stateField,
+            string postcodeField)
+        {
+            var warnings = new List<string>();
+            var addressSamples = new List<string>();
+            var postcodeSamples = new List<string>();
+            bool sampledSelectedPostcodeWithDigits = false;
+            bool sampledSelectedPostcodeWithoutDigits = false;
+            bool sampledUnitValues = false;
+
+            using var featureClass = layer.GetFeatureClass();
+            int previewRowCount = 0;
+            using var cursor = featureClass.Search(new QueryFilter(), false);
+            while (cursor.MoveNext() && previewRowCount < 25)
+            {
+                previewRowCount++;
+                using var row = cursor.Current;
+                string address = BuildAddressValue(row, addressField, streetNumberField, streetFractionField, streetPrefixField, streetNameField, streetTypeField, streetSuffixField, unitField);
+                if (!string.IsNullOrWhiteSpace(address) && addressSamples.Count < 5)
+                    addressSamples.Add(address);
+
+                string selectedPostcode = CleanPart(GetRowValue(row, postcodeField));
+                if (!string.IsNullOrWhiteSpace(selectedPostcode))
+                {
+                    if (selectedPostcode.Any(char.IsDigit))
+                        sampledSelectedPostcodeWithDigits = true;
+                    else
+                        sampledSelectedPostcodeWithoutDigits = true;
+                }
+
+                string postcode = BuildPostcodeValue(row, postcodeField, inputFields);
+                if (!string.IsNullOrWhiteSpace(postcode))
+                    postcodeSamples.Add(postcode);
+
+                if (!sampledUnitValues && !string.IsNullOrWhiteSpace(GetRowValue(row, unitField)))
+                    sampledUnitValues = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(idField))
+                warnings.Add("Unique ID is required.");
+            if (string.IsNullOrWhiteSpace(addressField) && string.IsNullOrWhiteSpace(streetNameField))
+                warnings.Add("No full-address or street-name field is selected.");
+            if (sampledSelectedPostcodeWithoutDigits && !sampledSelectedPostcodeWithDigits)
+                warnings.Add($"Selected postcode field '{postcodeField}' has no digits in the preview sample; export will fall back to known ZIP/postcode aliases when possible.");
+            if (HasLikelyDirectionField(inputFields) && string.IsNullOrWhiteSpace(streetPrefixField) && string.IsNullOrWhiteSpace(streetSuffixField))
+                warnings.Add("A likely street direction field exists, but Prefix and Suffix are blank.");
+            if (sampledUnitValues)
+                warnings.Add("Unit/subaddress values are present. Overture Addresses may only contain base address candidates for some records.");
+
+            string mappingText = string.Join(Environment.NewLine, new[]
+            {
+                $"Unique ID: {FormatField(idField)}",
+                $"Name: {FormatField(nameField)}",
+                $"Full Address: {FormatField(addressField)}",
+                $"Number: {FormatField(streetNumberField)}",
+                $"Fraction: {FormatField(streetFractionField)}",
+                $"Prefix: {FormatField(streetPrefixField)}",
+                $"Street: {FormatField(streetNameField)}",
+                $"Type: {FormatField(streetTypeField)}",
+                $"Suffix: {FormatField(streetSuffixField)}",
+                $"Unit: {FormatField(unitField)}",
+                $"City: {FormatField(cityField)}",
+                $"State: {FormatField(stateField)}",
+                $"Postcode: {FormatField(postcodeField)}"
+            });
+
+            string sampleText = string.Join(Environment.NewLine,
+                addressSamples
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Take(3)
+                    .Select((value, index) => $"Address sample {index + 1}: {value}")
+                    .Concat(postcodeSamples
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Take(3)
+                        .Select((value, index) => $"Postcode sample {index + 1}: {value}")));
+
+            if (string.IsNullOrWhiteSpace(sampleText))
+                sampleText = "No non-empty address or postcode samples found in the first preview rows.";
+
+            return new FieldMappingPreview(
+                $"{mappingText}{Environment.NewLine}{Environment.NewLine}{sampleText}",
+                warnings.Count == 0 ? "Mapping preview found no obvious issues in the sample." : string.Join(Environment.NewLine, warnings.Select(warning => $"- {warning}")));
+        }
+
+        private static bool HasLikelyDirectionField(IEnumerable<string> fields)
+        {
+            return fields.Any(field =>
+            {
+                string normalized = NormalizeFieldName(field);
+                return normalized.Contains("direction", StringComparison.OrdinalIgnoreCase) ||
+                       normalized.EndsWith("dir", StringComparison.OrdinalIgnoreCase) ||
+                       normalized.Contains("predir", StringComparison.OrdinalIgnoreCase) ||
+                       normalized.Contains("postdir", StringComparison.OrdinalIgnoreCase);
+            });
+        }
+
+        private static string FormatField(string fieldName) =>
+            string.IsNullOrWhiteSpace(fieldName) ? "(blank)" : fieldName;
 
         private async Task RunGersifyAsync()
         {
@@ -667,6 +891,11 @@ namespace DuckDBGeoparquet.Views
                 sb.AppendLine("record_id,name,address,city,state,postcode,longitude,latitude");
 
                 using var featureClass = layer.GetFeatureClass();
+                var availableFields = featureClass.GetDefinition()
+                    .GetFields()
+                    .Select(field => field.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
                 using var cursor = featureClass.Search(new QueryFilter(), false);
                 while (cursor.MoveNext())
                 {
@@ -704,7 +933,7 @@ namespace DuckDBGeoparquet.Views
                         Csv(BuildAddressValue(row, addressField, streetNumberField, streetFractionField, streetPrefixField, streetNameField, streetTypeField, streetSuffixField, unitField)),
                         Csv(GetRowValue(row, cityField)),
                         Csv(GetRowValue(row, stateField)),
-                        Csv(BuildPostcodeValue(row, postcodeField)),
+                        Csv(BuildPostcodeValue(row, postcodeField, availableFields)),
                         point.X.ToString("G", CultureInfo.InvariantCulture),
                         point.Y.ToString("G", CultureInfo.InvariantCulture)));
 
@@ -1029,13 +1258,13 @@ namespace DuckDBGeoparquet.Views
                 .Where(part => !string.IsNullOrWhiteSpace(part)));
         }
 
-        private static string BuildPostcodeValue(Row row, string postcodeField)
+        private static string BuildPostcodeValue(Row row, string postcodeField, IReadOnlyCollection<string> availableFields = null)
         {
             string postcode = CleanPart(GetRowValue(row, postcodeField));
             if (postcode.Any(char.IsDigit))
                 return postcode;
 
-            string fallbackPostcode = SelectFirstNumericRowValue(row,
+            string fallbackPostcode = SelectFirstNumericRowValue(row, availableFields,
                 "ADDRESS_ZIP5",
                 "address_zip5",
                 "ZIP5",
@@ -1050,10 +1279,13 @@ namespace DuckDBGeoparquet.Views
             return fallbackPostcode;
         }
 
-        private static string SelectFirstNumericRowValue(Row row, params string[] fieldNames)
+        private static string SelectFirstNumericRowValue(Row row, IReadOnlyCollection<string> availableFields, params string[] fieldNames)
         {
             foreach (string fieldName in fieldNames)
             {
+                if (availableFields != null && !availableFields.Contains(fieldName, StringComparer.OrdinalIgnoreCase))
+                    continue;
+
                 string value = CleanPart(GetRowValue(row, fieldName));
                 if (value.Any(char.IsDigit))
                     return value;
@@ -1099,6 +1331,7 @@ namespace DuckDBGeoparquet.Views
         }
 
         private sealed record GersifyInputExport(string CsvPath, int FeatureCount, ExtentBounds Extent);
+        private sealed record FieldMappingPreview(string PreviewText, string WarningText);
     }
 
     public sealed class LayerSelectionItem

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -448,10 +448,10 @@ namespace DuckDBGeoparquet.Views
             SelectedAddressField = SelectField(fields, "address", "full_address", "street_address", "addr", "situs");
             SelectedStreetNumberField = SelectField(fields, "address_number", "address_num", "addressno", "house_number", "housenumber", "addrnum", "saddno", "situs_number", "number");
             SelectedStreetFractionField = SelectField(fields, "address_fraction", "fraction", "saddfrac");
-            SelectedStreetPrefixField = SelectField(fields, "address_prefix", "address_street_prefix", "street_prefix", "street_predir", "predir", "pre_direction", "saddpref", "prefix");
+            SelectedStreetPrefixField = SelectField(fields, "address_prefix", "address_street_prefix", "address_direction", "street_direction", "street_dir", "street_pre_direction", "street_predirection", "street_pre_dir", "street_prefix", "street_predir", "predir", "pre_direction", "pre_dir", "saddpref", "prefix");
             SelectedStreetNameField = SelectField(fields, "address_street_name", "address_street", "address_road", "street_name", "street", "road", "saddstr", "streetname");
             SelectedStreetTypeField = SelectField(fields, "address_street_type", "address_type", "street_type", "sttype", "saddsttyp", "street_suffix_type");
-            SelectedStreetSuffixField = SelectField(fields, "address_suffix", "address_street_suffix", "street_suffix", "street_postdir", "postdir", "post_direction", "saddstsuf", "suffix");
+            SelectedStreetSuffixField = SelectField(fields, "address_suffix", "address_street_suffix", "address_post_direction", "street_suffix", "street_post_direction", "street_postdirection", "street_post_dir", "street_postdir", "postdir", "post_direction", "post_dir", "saddstsuf", "suffix");
             SelectedUnitField = SelectField(fields, "address_unit", "unit", "apt", "apartment", "suite", "sunit");
             SelectedCityField = SelectField(fields, "address_zipcity", "city", "locality", "town", "scity");
             SelectedStateField = SelectField(fields, "address_state", "state", "region", "province", "state2");

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -1032,7 +1032,34 @@ namespace DuckDBGeoparquet.Views
         private static string BuildPostcodeValue(Row row, string postcodeField)
         {
             string postcode = CleanPart(GetRowValue(row, postcodeField));
-            return postcode.Any(char.IsDigit) ? postcode : string.Empty;
+            if (postcode.Any(char.IsDigit))
+                return postcode;
+
+            string fallbackPostcode = SelectFirstNumericRowValue(row,
+                "ADDRESS_ZIP5",
+                "address_zip5",
+                "ZIP5",
+                "zip5",
+                "POSTCODE",
+                "postcode",
+                "POSTAL_CODE",
+                "postal_code",
+                "ZIP",
+                "zip",
+                "ADDRESS_ZIP4");
+            return fallbackPostcode;
+        }
+
+        private static string SelectFirstNumericRowValue(Row row, params string[] fieldNames)
+        {
+            foreach (string fieldName in fieldNames)
+            {
+                string value = CleanPart(GetRowValue(row, fieldName));
+                if (value.Any(char.IsDigit))
+                    return value;
+            }
+
+            return string.Empty;
         }
 
         private static string CleanPart(string value)

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -28,6 +28,7 @@ namespace DuckDBGeoparquet.Views
         private bool _isBusy;
         private LayerSelectionItem _selectedInputLayer;
         private LayerSelectionItem _selectedTraceLayer;
+        private GersifyTargetOption _selectedGersifyTarget;
         private string _selectedIdField;
         private string _selectedNameField;
         private string _selectedAddressField;
@@ -49,6 +50,7 @@ namespace DuckDBGeoparquet.Views
         private string _nameSimilarityThreshold = "0.86";
         private string _addressSimilarityThreshold = "0.72";
         private string _acceptScoreThreshold = "72";
+        private bool _allowNearbyOnlyMatches;
         private string _bridgeRoot = "https://overturemapswestus2.blob.core.windows.net/bridgefiles";
         private string _bridgeRelease = GersifyOptions.DefaultReleaseVersion;
         private string _bridgeTheme = "places";
@@ -60,9 +62,15 @@ namespace DuckDBGeoparquet.Views
         {
             InputLayers = [];
             TraceLayers = [];
+            GersifyTargets =
+            [
+                new GersifyTargetOption("Addresses", GersifyTargetType.Addresses, "Validate address points against Overture Addresses."),
+                new GersifyTargetOption("Places", GersifyTargetType.Places, "Enrich local places or facilities with Overture Places GERS IDs.")
+            ];
             InputFields = [];
             OptionalInputFields = [];
             TraceFields = [];
+            SelectedGersifyTarget = GersifyTargets.FirstOrDefault();
 
             string addinDataBase = ProjectDataLocator.GetAddinDataBase();
             ReleaseFolderPath = ProjectDataLocator.GetNewestLoadedReleaseFolder();
@@ -90,9 +98,28 @@ namespace DuckDBGeoparquet.Views
 
         public ObservableCollection<LayerSelectionItem> InputLayers { get; }
         public ObservableCollection<LayerSelectionItem> TraceLayers { get; }
+        public ObservableCollection<GersifyTargetOption> GersifyTargets { get; }
         public ObservableCollection<string> InputFields { get; }
         public ObservableCollection<string> OptionalInputFields { get; }
         public ObservableCollection<string> TraceFields { get; }
+
+        public GersifyTargetOption SelectedGersifyTarget
+        {
+            get => _selectedGersifyTarget;
+            set
+            {
+                if (SetProperty(ref _selectedGersifyTarget, value))
+                {
+                    if (value != null)
+                    {
+                        BridgeTheme = value.TargetTheme;
+                        BridgeType = value.TargetDatasetType;
+                    }
+
+                    RaiseCommandStatesChanged();
+                }
+            }
+        }
 
         public LayerSelectionItem SelectedInputLayer
         {
@@ -310,6 +337,12 @@ namespace DuckDBGeoparquet.Views
             set => SetProperty(ref _acceptScoreThreshold, value);
         }
 
+        public bool AllowNearbyOnlyMatches
+        {
+            get => _allowNearbyOnlyMatches;
+            set => SetProperty(ref _allowNearbyOnlyMatches, value);
+        }
+
         public string BridgeRoot
         {
             get => _bridgeRoot;
@@ -496,8 +529,10 @@ namespace DuckDBGeoparquet.Views
                 });
 
                 using var service = new GersifyService();
-                var result = await service.GersifyPlacesAsync(new GersifyOptions
+                var targetType = SelectedGersifyTarget?.TargetType ?? GersifyTargetType.Addresses;
+                var result = await service.GersifyAsync(new GersifyOptions
                 {
+                    TargetType = targetType,
                     InputCsvPath = export.CsvPath,
                     InputLayerName = SelectedInputLayer.Name,
                     UniqueIdField = SelectedIdField,
@@ -520,22 +555,28 @@ namespace DuckDBGeoparquet.Views
                     MaxDistanceMeters = ParseDouble(MaxDistanceMeters, 75),
                     NameSimilarityThreshold = ParseDouble(NameSimilarityThreshold, 0.86),
                     AddressSimilarityThreshold = ParseDouble(AddressSimilarityThreshold, 0.72),
-                    AcceptScoreThreshold = ParseDouble(AcceptScoreThreshold, 72)
+                    AcceptScoreThreshold = ParseDouble(AcceptScoreThreshold, 72),
+                    AllowNearbyOnlyMatches = AllowNearbyOnlyMatches
                 }, progress);
 
                 StatusText = "Adding GERSify outputs to the map...";
-                string layerName = $"GERSified_{SelectedInputLayer.Name}";
+                string targetSuffix = string.IsNullOrWhiteSpace(result.TargetDatasetType) ? "data" : result.TargetDatasetType;
+                string layerName = $"GERSified_{SelectedInputLayer.Name}_{targetSuffix}";
                 result.OutputFeatureClassPath = await WriteGersifiedFeatureClassAsync(result.OutputCsvPath, OutputFolder, layerName);
                 await TryAddStandaloneTableAsync(result.CandidateCsvPath);
                 await TryAddStandaloneTableAsync(result.BridgeCsvPath);
 
                 StatusText = $"Matched {result.AcceptedCount:N0} of {result.InputCount:N0} feature(s); reviewed {result.CandidateCount:N0} candidate(s).";
+                AddToLog($"Target: {result.TargetLabel} ({result.TargetTheme}/{result.TargetDatasetType}).");
                 AddToLog($"Input text coverage: {result.InputNameCount:N0} with names; {result.InputAddressCount:N0} with addresses.");
                 AddToLog($"Overture candidate address coverage: {result.CandidateOvertureAddressCount:N0} with address text; {result.CandidateAddressSimilarityCount:N0} with address similarity scores.");
-                if (result.CandidateCount > 0 && result.CandidateAddressSimilarityCount == 0)
+                if (string.Equals(result.TargetDatasetType, "place", StringComparison.OrdinalIgnoreCase) &&
+                    result.CandidateCount > 0 &&
+                    result.CandidateAddressSimilarityCount == 0)
                 {
                     AddToLog("No address similarity scores were produced. The selected Overture Places files likely do not include address_freeform/address_* fields or nested addresses; close map layers using old Places files and re-download Places with this add-in version to enable address-based GERSify scoring.");
                 }
+                AddToLog($"Accepted by strategy: {FormatStrategyCounts(result.AcceptedStrategyCounts)}.");
                 AddToLog($"Candidates reviewed: {result.CandidateCount:N0}; accepted matches: {result.AcceptedCount:N0}.");
                 AddToLog($"Output feature class: {result.OutputFeatureClassPath}");
                 AddToLog($"Candidate review CSV: {result.CandidateCsvPath}");
@@ -809,6 +850,7 @@ namespace DuckDBGeoparquet.Views
         {
             return !IsRunning &&
                    SelectedInputLayer?.Layer != null &&
+                   SelectedGersifyTarget != null &&
                    !string.IsNullOrWhiteSpace(SelectedIdField) &&
                    HasAnyGersifyMatchField() &&
                    !string.IsNullOrWhiteSpace(OutputFolder);
@@ -897,6 +939,22 @@ namespace DuckDBGeoparquet.Views
         {
             _logBuilder.Clear();
             LogText = string.Empty;
+        }
+
+        private static string FormatStrategyCounts(IReadOnlyDictionary<string, int> counts)
+        {
+            if (counts == null || counts.Count == 0)
+                return "none";
+
+            string[] preferredOrder = ["exact_address", "address", "name_address", "name", "nearby_only"];
+            var ordered = preferredOrder
+                .Where(counts.ContainsKey)
+                .Select(strategy => new KeyValuePair<string, int>(strategy, counts[strategy]))
+                .Concat(counts
+                    .Where(item => !preferredOrder.Contains(item.Key, StringComparer.OrdinalIgnoreCase))
+                    .OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase));
+
+            return string.Join("; ", ordered.Select(item => $"{item.Key}: {item.Value:N0}"));
         }
 
         private static string SelectField(IEnumerable<string> fields, params string[] candidates)
@@ -1020,5 +1078,21 @@ namespace DuckDBGeoparquet.Views
 
         public string Name { get; }
         public FeatureLayer Layer { get; }
+    }
+
+    public sealed class GersifyTargetOption
+    {
+        public GersifyTargetOption(string name, GersifyTargetType targetType, string description)
+        {
+            Name = name;
+            TargetType = targetType;
+            Description = description;
+        }
+
+        public string Name { get; }
+        public GersifyTargetType TargetType { get; }
+        public string Description { get; }
+        public string TargetTheme => TargetType == GersifyTargetType.Addresses ? "addresses" : "places";
+        public string TargetDatasetType => TargetType == GersifyTargetType.Addresses ? "address" : "place";
     }
 }

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -23,7 +23,7 @@ namespace DuckDBGeoparquet.Views
 {
     internal class GersifyDockpaneViewModel : DockPane
     {
-        private const string DockPaneId = "DuckDBGeoparquet_Views_GersifyDockpane";
+        private const string DockPaneId = "DuckDBGeoparquet_Views_GersifyDockpane_V2";
         private readonly StringBuilder _logBuilder = new();
         private bool _isBusy;
         private LayerSelectionItem _selectedInputLayer;

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -413,12 +413,12 @@ namespace DuckDBGeoparquet.Views
             SelectedIdField = SelectField(fields, "id", "record_id", "objectid", "fid", "globalid") ?? fields.FirstOrDefault();
             SelectedNameField = SelectField(fields, "name", "business_name", "poi_name", "label", "title");
             SelectedAddressField = SelectField(fields, "address", "full_address", "street_address", "addr", "situs");
-            SelectedStreetNumberField = SelectField(fields, "address_number", "house_number", "housenumber", "addrnum", "saddno", "number");
+            SelectedStreetNumberField = SelectField(fields, "address_number", "address_num", "addressno", "house_number", "housenumber", "addrnum", "saddno", "situs_number", "number");
             SelectedStreetFractionField = SelectField(fields, "address_fraction", "fraction", "saddfrac");
-            SelectedStreetPrefixField = SelectField(fields, "address_prefix", "street_prefix", "predir", "saddpref", "prefix");
-            SelectedStreetNameField = SelectField(fields, "address_street", "street_name", "street", "road", "saddstr", "streetname");
-            SelectedStreetTypeField = SelectField(fields, "address_type", "street_type", "sttype", "saddsttyp");
-            SelectedStreetSuffixField = SelectField(fields, "address_suffix", "street_suffix", "postdir", "saddstsuf", "suffix");
+            SelectedStreetPrefixField = SelectField(fields, "address_prefix", "address_street_prefix", "street_prefix", "street_predir", "predir", "pre_direction", "saddpref", "prefix");
+            SelectedStreetNameField = SelectField(fields, "address_street_name", "address_street", "address_road", "street_name", "street", "road", "saddstr", "streetname");
+            SelectedStreetTypeField = SelectField(fields, "address_street_type", "address_type", "street_type", "sttype", "saddsttyp", "street_suffix_type");
+            SelectedStreetSuffixField = SelectField(fields, "address_suffix", "address_street_suffix", "street_suffix", "street_postdir", "postdir", "post_direction", "saddstsuf", "suffix");
             SelectedUnitField = SelectField(fields, "address_unit", "unit", "apt", "apartment", "suite", "sunit");
             SelectedCityField = SelectField(fields, "address_zipcity", "city", "locality", "town", "scity");
             SelectedStateField = SelectField(fields, "address_state", "state", "region", "province", "state2");
@@ -529,7 +529,9 @@ namespace DuckDBGeoparquet.Views
                 await TryAddStandaloneTableAsync(result.CandidateCsvPath);
                 await TryAddStandaloneTableAsync(result.BridgeCsvPath);
 
-                StatusText = $"Matched {result.AcceptedCount:N0} of {result.InputCount:N0} feature(s).";
+                StatusText = $"Matched {result.AcceptedCount:N0} of {result.InputCount:N0} feature(s); reviewed {result.CandidateCount:N0} candidate(s).";
+                AddToLog($"Input text coverage: {result.InputNameCount:N0} with names; {result.InputAddressCount:N0} with addresses.");
+                AddToLog($"Candidates reviewed: {result.CandidateCount:N0}; accepted matches: {result.AcceptedCount:N0}.");
                 AddToLog($"Output feature class: {result.OutputFeatureClassPath}");
                 AddToLog($"Candidate review CSV: {result.CandidateCsvPath}");
                 AddToLog($"Bridge CSV: {result.BridgeCsvPath}");

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -704,7 +704,7 @@ namespace DuckDBGeoparquet.Views
                         Csv(BuildAddressValue(row, addressField, streetNumberField, streetFractionField, streetPrefixField, streetNameField, streetTypeField, streetSuffixField, unitField)),
                         Csv(GetRowValue(row, cityField)),
                         Csv(GetRowValue(row, stateField)),
-                        Csv(GetRowValue(row, postcodeField)),
+                        Csv(BuildPostcodeValue(row, postcodeField)),
                         point.X.ToString("G", CultureInfo.InvariantCulture),
                         point.Y.ToString("G", CultureInfo.InvariantCulture)));
 
@@ -1027,6 +1027,12 @@ namespace DuckDBGeoparquet.Views
                     CleanPart(GetRowValue(row, unitField))
                 }
                 .Where(part => !string.IsNullOrWhiteSpace(part)));
+        }
+
+        private static string BuildPostcodeValue(Row row, string postcodeField)
+        {
+            string postcode = CleanPart(GetRowValue(row, postcodeField));
+            return postcode.Any(char.IsDigit) ? postcode : string.Empty;
         }
 
         private static string CleanPart(string value)

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -534,7 +534,7 @@ namespace DuckDBGeoparquet.Views
                 AddToLog($"Overture candidate address coverage: {result.CandidateOvertureAddressCount:N0} with address text; {result.CandidateAddressSimilarityCount:N0} with address similarity scores.");
                 if (result.CandidateCount > 0 && result.CandidateAddressSimilarityCount == 0)
                 {
-                    AddToLog("No address similarity scores were produced. The selected Overture Places files likely do not include flattened place address fields; re-download Places with this add-in version to enable address-based GERSify scoring.");
+                    AddToLog("No address similarity scores were produced. The selected Overture Places files likely do not include address_freeform/address_* fields or nested addresses; close map layers using old Places files and re-download Places with this add-in version to enable address-based GERSify scoring.");
                 }
                 AddToLog($"Candidates reviewed: {result.CandidateCount:N0}; accepted matches: {result.AcceptedCount:N0}.");
                 AddToLog($"Output feature class: {result.OutputFeatureClassPath}");
@@ -773,7 +773,7 @@ namespace DuckDBGeoparquet.Views
                 var map = MapView.Active?.Map;
                 if (map != null)
                 {
-                    LayerFactory.Instance.CreateLayer(new Uri(outputFeatureClassPath), map, layerName: featureClassName);
+                    LayerFactory.Instance.CreateLayer(ToFileUri(outputFeatureClassPath), map, layerName: featureClassName);
                 }
             });
 
@@ -792,7 +792,7 @@ namespace DuckDBGeoparquet.Views
                     var map = MapView.Active?.Map;
                     if (map != null)
                     {
-                        StandaloneTableFactory.Instance.CreateStandaloneTable(new Uri(tablePath), map);
+                        StandaloneTableFactory.Instance.CreateStandaloneTable(ToFileUri(tablePath), map);
                     }
                 }
                 catch (Exception ex)
@@ -801,6 +801,9 @@ namespace DuckDBGeoparquet.Views
                 }
             });
         }
+
+        private static Uri ToFileUri(string path) =>
+            new(Path.GetFullPath(path), UriKind.Absolute);
 
         private bool CanRunGersify()
         {

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -1,0 +1,850 @@
+using ArcGIS.Core.Data;
+using ArcGIS.Core.Geometry;
+using ArcGIS.Desktop.Core;
+using ArcGIS.Desktop.Core.Geoprocessing;
+using ArcGIS.Desktop.Framework;
+using ArcGIS.Desktop.Framework.Contracts;
+using ArcGIS.Desktop.Framework.Threading.Tasks;
+using ArcGIS.Desktop.Mapping;
+using DuckDBGeoparquet.Models;
+using DuckDBGeoparquet.Services;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using System.Windows.Forms;
+
+namespace DuckDBGeoparquet.Views
+{
+    internal class GersifyDockpaneViewModel : DockPane
+    {
+        private const string DockPaneId = "DuckDBGeoparquet_Views_GersifyDockpane";
+        private readonly StringBuilder _logBuilder = new();
+        private bool _isBusy;
+        private LayerSelectionItem _selectedInputLayer;
+        private LayerSelectionItem _selectedTraceLayer;
+        private string _selectedIdField;
+        private string _selectedNameField;
+        private string _selectedAddressField;
+        private string _selectedCityField;
+        private string _selectedStateField;
+        private string _selectedPostcodeField;
+        private string _selectedTraceGersIdField;
+        private string _releaseFolderPath;
+        private string _outputFolder;
+        private string _datasetName = "user_data";
+        private string _maxDistanceMeters = "75";
+        private string _nameSimilarityThreshold = "0.86";
+        private string _addressSimilarityThreshold = "0.72";
+        private string _acceptScoreThreshold = "72";
+        private string _bridgeRoot = "https://overturemapswestus2.blob.core.windows.net/bridgefiles";
+        private string _bridgeRelease = GersifyOptions.DefaultReleaseVersion;
+        private string _bridgeTheme = "places";
+        private string _bridgeType = "place";
+        private string _statusText = "Ready.";
+        private string _logText = string.Empty;
+
+        protected GersifyDockpaneViewModel()
+        {
+            InputLayers = [];
+            TraceLayers = [];
+            InputFields = [];
+            OptionalInputFields = [];
+            TraceFields = [];
+
+            string addinDataBase = ProjectDataLocator.GetAddinDataBase();
+            ReleaseFolderPath = ProjectDataLocator.GetNewestLoadedReleaseFolder();
+            OutputFolder = Path.Combine(addinDataBase, "GERSify");
+
+            RefreshLayersCommand = new RelayCommand(async () => await RefreshLayersAsync(), () => !IsRunning);
+            BrowseReleaseFolderCommand = new RelayCommand(() => BrowseReleaseFolder(), () => !IsRunning);
+            BrowseOutputFolderCommand = new RelayCommand(() => BrowseOutputFolder(), () => !IsRunning);
+            RunGersifyCommand = new RelayCommand(async () => await RunGersifyAsync(), CanRunGersify);
+            RunTraceSourcesCommand = new RelayCommand(async () => await RunTraceSourcesAsync(), CanRunTraceSources);
+        }
+
+        protected override async Task InitializeAsync()
+        {
+            await RefreshLayersAsync();
+        }
+
+        public static void Show()
+        {
+            if (FrameworkApplication.DockPaneManager.Find(DockPaneId) is GersifyDockpaneViewModel pane)
+            {
+                pane.Activate();
+            }
+        }
+
+        public ObservableCollection<LayerSelectionItem> InputLayers { get; }
+        public ObservableCollection<LayerSelectionItem> TraceLayers { get; }
+        public ObservableCollection<string> InputFields { get; }
+        public ObservableCollection<string> OptionalInputFields { get; }
+        public ObservableCollection<string> TraceFields { get; }
+
+        public LayerSelectionItem SelectedInputLayer
+        {
+            get => _selectedInputLayer;
+            set
+            {
+                if (SetProperty(ref _selectedInputLayer, value))
+                {
+                    _ = RefreshInputFieldsAsync(value);
+                    RaiseCommandStatesChanged();
+                }
+            }
+        }
+
+        public LayerSelectionItem SelectedTraceLayer
+        {
+            get => _selectedTraceLayer;
+            set
+            {
+                if (SetProperty(ref _selectedTraceLayer, value))
+                {
+                    _ = RefreshTraceFieldsAsync(value);
+                    RaiseCommandStatesChanged();
+                }
+            }
+        }
+
+        public string SelectedIdField
+        {
+            get => _selectedIdField;
+            set
+            {
+                if (SetProperty(ref _selectedIdField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedNameField
+        {
+            get => _selectedNameField;
+            set
+            {
+                if (SetProperty(ref _selectedNameField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedAddressField
+        {
+            get => _selectedAddressField;
+            set => SetProperty(ref _selectedAddressField, value);
+        }
+
+        public string SelectedCityField
+        {
+            get => _selectedCityField;
+            set => SetProperty(ref _selectedCityField, value);
+        }
+
+        public string SelectedStateField
+        {
+            get => _selectedStateField;
+            set => SetProperty(ref _selectedStateField, value);
+        }
+
+        public string SelectedPostcodeField
+        {
+            get => _selectedPostcodeField;
+            set => SetProperty(ref _selectedPostcodeField, value);
+        }
+
+        public string SelectedTraceGersIdField
+        {
+            get => _selectedTraceGersIdField;
+            set
+            {
+                if (SetProperty(ref _selectedTraceGersIdField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string ReleaseFolderPath
+        {
+            get => _releaseFolderPath;
+            set
+            {
+                if (SetProperty(ref _releaseFolderPath, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string OutputFolder
+        {
+            get => _outputFolder;
+            set
+            {
+                if (SetProperty(ref _outputFolder, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string DatasetName
+        {
+            get => _datasetName;
+            set => SetProperty(ref _datasetName, value);
+        }
+
+        public string MaxDistanceMeters
+        {
+            get => _maxDistanceMeters;
+            set => SetProperty(ref _maxDistanceMeters, value);
+        }
+
+        public string NameSimilarityThreshold
+        {
+            get => _nameSimilarityThreshold;
+            set => SetProperty(ref _nameSimilarityThreshold, value);
+        }
+
+        public string AddressSimilarityThreshold
+        {
+            get => _addressSimilarityThreshold;
+            set => SetProperty(ref _addressSimilarityThreshold, value);
+        }
+
+        public string AcceptScoreThreshold
+        {
+            get => _acceptScoreThreshold;
+            set => SetProperty(ref _acceptScoreThreshold, value);
+        }
+
+        public string BridgeRoot
+        {
+            get => _bridgeRoot;
+            set => SetProperty(ref _bridgeRoot, value);
+        }
+
+        public string BridgeRelease
+        {
+            get => _bridgeRelease;
+            set => SetProperty(ref _bridgeRelease, value);
+        }
+
+        public string BridgeTheme
+        {
+            get => _bridgeTheme;
+            set => SetProperty(ref _bridgeTheme, value);
+        }
+
+        public string BridgeType
+        {
+            get => _bridgeType;
+            set => SetProperty(ref _bridgeType, value);
+        }
+
+        public bool IsRunning
+        {
+            get => _isBusy;
+            set
+            {
+                if (SetProperty(ref _isBusy, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string StatusText
+        {
+            get => _statusText;
+            set => SetProperty(ref _statusText, value);
+        }
+
+        public string LogText
+        {
+            get => _logText;
+            set => SetProperty(ref _logText, value);
+        }
+
+        public ICommand RefreshLayersCommand { get; }
+        public ICommand BrowseReleaseFolderCommand { get; }
+        public ICommand BrowseOutputFolderCommand { get; }
+        public ICommand RunGersifyCommand { get; }
+        public ICommand RunTraceSourcesCommand { get; }
+
+        private async Task RefreshLayersAsync()
+        {
+            try
+            {
+                var layers = await QueuedTask.Run(() =>
+                {
+                    var map = MapView.Active?.Map;
+                    if (map == null)
+                        return new List<LayerSelectionItem>();
+
+                    return map.GetLayersAsFlattenedList()
+                        .OfType<FeatureLayer>()
+                        .Select(layer => new LayerSelectionItem(layer.Name, layer))
+                        .OrderBy(layer => layer.Name, StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                });
+
+                InputLayers.Clear();
+                TraceLayers.Clear();
+                foreach (var layer in layers)
+                {
+                    InputLayers.Add(layer);
+                    TraceLayers.Add(layer);
+                }
+
+                SelectedInputLayer ??= InputLayers.FirstOrDefault();
+                SelectedTraceLayer ??= TraceLayers.FirstOrDefault();
+                StatusText = layers.Count == 0 ? "Open a map with feature layers to start." : $"Found {layers.Count} feature layer(s).";
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"Could not refresh map layers: {ex.Message}";
+                AddToLog(ex.ToString());
+            }
+        }
+
+        private async Task RefreshInputFieldsAsync(LayerSelectionItem layerItem)
+        {
+            var fields = await ReadLayerFieldsAsync(layerItem);
+            InputFields.Clear();
+            OptionalInputFields.Clear();
+            OptionalInputFields.Add(string.Empty);
+            foreach (var field in fields)
+            {
+                InputFields.Add(field);
+                OptionalInputFields.Add(field);
+            }
+
+            SelectedIdField = SelectField(fields, "id", "record_id", "objectid", "fid", "globalid") ?? fields.FirstOrDefault();
+            SelectedNameField = SelectField(fields, "name", "business_name", "poi_name", "label", "title");
+            SelectedAddressField = SelectField(fields, "address", "full_address", "street_address", "addr", "situs");
+            SelectedCityField = SelectField(fields, "city", "locality", "town");
+            SelectedStateField = SelectField(fields, "state", "region", "province");
+            SelectedPostcodeField = SelectField(fields, "postcode", "postal_code", "zip", "zip5");
+        }
+
+        private async Task RefreshTraceFieldsAsync(LayerSelectionItem layerItem)
+        {
+            var fields = await ReadLayerFieldsAsync(layerItem);
+            TraceFields.Clear();
+            foreach (var field in fields)
+            {
+                TraceFields.Add(field);
+            }
+
+            SelectedTraceGersIdField = SelectField(fields, "gers_id", "id", "overture_id") ?? fields.FirstOrDefault();
+        }
+
+        private static async Task<List<string>> ReadLayerFieldsAsync(LayerSelectionItem layerItem)
+        {
+            if (layerItem?.Layer == null)
+                return [];
+
+            return await QueuedTask.Run(() =>
+            {
+                using var featureClass = layerItem.Layer.GetFeatureClass();
+                var definition = featureClass.GetDefinition();
+                return definition.GetFields()
+                    .Select(field => field.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            });
+        }
+
+        private async Task RunGersifyAsync()
+        {
+            IsRunning = true;
+            ClearLog();
+            string inputCsvPath = null;
+            try
+            {
+                string releaseFolder = ResolveReleaseFolder();
+                if (string.IsNullOrWhiteSpace(releaseFolder) || !Directory.Exists(releaseFolder))
+                {
+                    StatusText = "Choose a loaded Overture release folder.";
+                    return;
+                }
+
+                Directory.CreateDirectory(OutputFolder);
+                StatusText = "Exporting input points...";
+                AddToLog($"Input layer: {SelectedInputLayer.Name}");
+                var export = await ExportPointLayerAsync(
+                    SelectedInputLayer.Layer,
+                    SelectedIdField,
+                    SelectedNameField,
+                    SelectedAddressField,
+                    SelectedCityField,
+                    SelectedStateField,
+                    SelectedPostcodeField);
+                inputCsvPath = export.CsvPath;
+                AddToLog($"Exported {export.FeatureCount:N0} point feature(s).");
+
+                var progress = new Progress<string>(message =>
+                {
+                    StatusText = message;
+                    AddToLog(message);
+                });
+
+                using var service = new GersifyService();
+                var result = await service.GersifyPlacesAsync(new GersifyOptions
+                {
+                    InputCsvPath = export.CsvPath,
+                    InputLayerName = SelectedInputLayer.Name,
+                    UniqueIdField = SelectedIdField,
+                    NameField = SelectedNameField,
+                    AddressField = SelectedAddressField,
+                    CityField = SelectedCityField,
+                    StateField = SelectedStateField,
+                    PostcodeField = SelectedPostcodeField,
+                    OvertureReleaseFolder = releaseFolder,
+                    OutputFolder = OutputFolder,
+                    DatasetName = string.IsNullOrWhiteSpace(DatasetName) ? "user_data" : DatasetName.Trim(),
+                    InputExtent = export.Extent,
+                    MaxDistanceMeters = ParseDouble(MaxDistanceMeters, 75),
+                    NameSimilarityThreshold = ParseDouble(NameSimilarityThreshold, 0.86),
+                    AddressSimilarityThreshold = ParseDouble(AddressSimilarityThreshold, 0.72),
+                    AcceptScoreThreshold = ParseDouble(AcceptScoreThreshold, 72)
+                }, progress);
+
+                StatusText = "Adding GERSify outputs to the map...";
+                string layerName = $"GERSified_{MfcUtility.SanitizeFileName(SelectedInputLayer.Name)}";
+                result.OutputFeatureClassPath = await WriteGersifiedFeatureClassAsync(result.OutputCsvPath, OutputFolder, layerName);
+                await TryAddStandaloneTableAsync(result.CandidateCsvPath);
+                await TryAddStandaloneTableAsync(result.BridgeCsvPath);
+
+                StatusText = $"Matched {result.AcceptedCount:N0} of {result.InputCount:N0} feature(s).";
+                AddToLog($"Output feature class: {result.OutputFeatureClassPath}");
+                AddToLog($"Candidate review CSV: {result.CandidateCsvPath}");
+                AddToLog($"Bridge CSV: {result.BridgeCsvPath}");
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"GERSify failed: {ex.Message}";
+                AddToLog(ex.ToString());
+            }
+            finally
+            {
+                TryDelete(inputCsvPath);
+                IsRunning = false;
+            }
+        }
+
+        private async Task RunTraceSourcesAsync()
+        {
+            IsRunning = true;
+            ClearLog();
+            string inputCsvPath = null;
+            try
+            {
+                Directory.CreateDirectory(OutputFolder);
+                StatusText = "Exporting GERS IDs...";
+                inputCsvPath = await ExportGersIdsAsync(SelectedTraceLayer.Layer, SelectedTraceGersIdField);
+                AddToLog($"Trace layer: {SelectedTraceLayer.Name}");
+
+                var progress = new Progress<string>(message =>
+                {
+                    StatusText = message;
+                    AddToLog(message);
+                });
+
+                using var service = new BridgeFileService();
+                var result = await service.TraceSourcesAsync(new TraceSourcesOptions
+                {
+                    InputCsvPath = inputCsvPath,
+                    OutputFolder = OutputFolder,
+                    BridgeRoot = BridgeRoot,
+                    Release = BridgeRelease,
+                    Theme = BridgeTheme,
+                    Type = BridgeType
+                }, progress);
+
+                await TryAddStandaloneTableAsync(result.OutputCsvPath);
+                StatusText = $"Found {result.OutputCount:N0} source record(s) for {result.InputCount:N0} GERS ID(s).";
+                AddToLog($"Source lookup CSV: {result.OutputCsvPath}");
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"Trace Sources failed: {ex.Message}";
+                AddToLog(ex.ToString());
+            }
+            finally
+            {
+                TryDelete(inputCsvPath);
+                IsRunning = false;
+            }
+        }
+
+        private static async Task<GersifyInputExport> ExportPointLayerAsync(
+            FeatureLayer layer,
+            string idField,
+            string nameField,
+            string addressField,
+            string cityField,
+            string stateField,
+            string postcodeField)
+        {
+            string csvPath = Path.Combine(Path.GetTempPath(), $"gersify_input_{Guid.NewGuid():N}.csv");
+            return await QueuedTask.Run(() =>
+            {
+                int count = 0;
+                double xMin = double.MaxValue;
+                double yMin = double.MaxValue;
+                double xMax = double.MinValue;
+                double yMax = double.MinValue;
+                var sb = new StringBuilder();
+                sb.AppendLine("record_id,name,address,city,state,postcode,longitude,latitude");
+
+                using var featureClass = layer.GetFeatureClass();
+                using var cursor = featureClass.Search(new QueryFilter(), false);
+                while (cursor.MoveNext())
+                {
+                    using var row = cursor.Current;
+                    if (row is not Feature feature)
+                        continue;
+
+                    Geometry geometry = feature.GetShape();
+                    if (geometry == null)
+                        continue;
+
+                    if (geometry.SpatialReference != null && geometry.SpatialReference.Wkid != 4326)
+                    {
+                        geometry = GeometryEngine.Instance.Project(geometry, SpatialReferences.WGS84);
+                    }
+
+                    MapPoint point = geometry as MapPoint;
+                    if (point == null && geometry.Extent != null)
+                    {
+                        point = geometry.Extent.Center;
+                    }
+
+                    if (point == null || double.IsNaN(point.X) || double.IsNaN(point.Y))
+                        continue;
+
+                    string recordId = GetRowValue(row, idField);
+                    if (string.IsNullOrWhiteSpace(recordId))
+                    {
+                        recordId = (count + 1).ToString(CultureInfo.InvariantCulture);
+                    }
+
+                    sb.AppendLine(string.Join(",",
+                        Csv(recordId),
+                        Csv(GetRowValue(row, nameField)),
+                        Csv(GetRowValue(row, addressField)),
+                        Csv(GetRowValue(row, cityField)),
+                        Csv(GetRowValue(row, stateField)),
+                        Csv(GetRowValue(row, postcodeField)),
+                        point.X.ToString("G", CultureInfo.InvariantCulture),
+                        point.Y.ToString("G", CultureInfo.InvariantCulture)));
+
+                    xMin = Math.Min(xMin, point.X);
+                    yMin = Math.Min(yMin, point.Y);
+                    xMax = Math.Max(xMax, point.X);
+                    yMax = Math.Max(yMax, point.Y);
+                    count++;
+                }
+
+                File.WriteAllText(csvPath, sb.ToString(), Encoding.UTF8);
+                ExtentBounds extent = count == 0 ? null : new ExtentBounds(xMin, yMin, xMax, yMax);
+                return new GersifyInputExport(csvPath, count, extent);
+            });
+        }
+
+        private static async Task<string> ExportGersIdsAsync(FeatureLayer layer, string gersIdField)
+        {
+            string csvPath = Path.Combine(Path.GetTempPath(), $"gers_trace_ids_{Guid.NewGuid():N}.csv");
+            return await QueuedTask.Run(() =>
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("gers_id");
+                using var featureClass = layer.GetFeatureClass();
+                using var cursor = featureClass.Search(new QueryFilter(), false);
+                while (cursor.MoveNext())
+                {
+                    using var row = cursor.Current;
+                    string gersId = GetRowValue(row, gersIdField);
+                    if (!string.IsNullOrWhiteSpace(gersId))
+                    {
+                        sb.AppendLine(Csv(gersId));
+                    }
+                }
+
+                File.WriteAllText(csvPath, sb.ToString(), Encoding.UTF8);
+                return csvPath;
+            });
+        }
+
+        private static async Task<string> WriteGersifiedFeatureClassAsync(string outputCsvPath, string outputFolder, string layerName)
+        {
+            string suffix = GersifyOptions.BuildTimestampSuffix();
+            string gdbPath;
+            if (string.Equals(Path.GetExtension(outputFolder), ".gdb", StringComparison.OrdinalIgnoreCase))
+            {
+                gdbPath = outputFolder;
+                if (!Directory.Exists(gdbPath))
+                {
+                    string parentFolder = Path.GetDirectoryName(gdbPath);
+                    string gdbName = Path.GetFileName(gdbPath);
+                    if (string.IsNullOrWhiteSpace(parentFolder) || string.IsNullOrWhiteSpace(gdbName))
+                    {
+                        throw new DirectoryNotFoundException($"Could not resolve file geodatabase path: {gdbPath}");
+                    }
+
+                    Directory.CreateDirectory(parentFolder);
+                    var createResult = await Geoprocessing.ExecuteToolAsync(
+                        "management.CreateFileGDB",
+                        Geoprocessing.MakeValueArray(parentFolder, gdbName),
+                        null,
+                        flags: GPExecuteToolFlags.None);
+                    if (createResult.IsFailed)
+                    {
+                        throw new InvalidOperationException("Create File Geodatabase failed: " +
+                            string.Join(" | ", createResult.Messages.Select(message => message.Text)));
+                    }
+                }
+            }
+            else
+            {
+                Directory.CreateDirectory(outputFolder);
+                string gdbName = $"GERSify_{suffix}.gdb";
+                gdbPath = Path.Combine(outputFolder, gdbName);
+                if (!Directory.Exists(gdbPath))
+                {
+                    var createResult = await Geoprocessing.ExecuteToolAsync(
+                        "management.CreateFileGDB",
+                        Geoprocessing.MakeValueArray(outputFolder, gdbName),
+                        null,
+                        flags: GPExecuteToolFlags.None);
+                    if (createResult.IsFailed)
+                    {
+                        throw new InvalidOperationException("Create File Geodatabase failed: " +
+                            string.Join(" | ", createResult.Messages.Select(message => message.Text)));
+                    }
+                }
+            }
+
+            string featureClassName = MfcUtility.SanitizeFileName(layerName);
+            if (featureClassName.Length > 50)
+                featureClassName = featureClassName[..50];
+
+            string outputFeatureClassPath = Path.Combine(gdbPath, featureClassName);
+            var result = await Geoprocessing.ExecuteToolAsync(
+                "management.XYTableToPoint",
+                Geoprocessing.MakeValueArray(outputCsvPath, outputFeatureClassPath, "longitude", "latitude", "", SpatialReferences.WGS84),
+                null,
+                flags: GPExecuteToolFlags.None);
+
+            if (result.IsFailed)
+            {
+                throw new InvalidOperationException("XY Table To Point failed: " +
+                    string.Join(" | ", result.Messages.Select(message => message.Text)));
+            }
+
+            await QueuedTask.Run(() =>
+            {
+                var map = MapView.Active?.Map;
+                if (map != null)
+                {
+                    LayerFactory.Instance.CreateLayer(new Uri(outputFeatureClassPath), map, layerName: featureClassName);
+                }
+            });
+
+            return outputFeatureClassPath;
+        }
+
+        private static async Task TryAddStandaloneTableAsync(string tablePath)
+        {
+            if (string.IsNullOrWhiteSpace(tablePath) || !File.Exists(tablePath))
+                return;
+
+            await QueuedTask.Run(() =>
+            {
+                try
+                {
+                    var map = MapView.Active?.Map;
+                    if (map != null)
+                    {
+                        StandaloneTableFactory.Instance.CreateStandaloneTable(new Uri(tablePath), map);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Could not add standalone table '{tablePath}': {ex.Message}");
+                }
+            });
+        }
+
+        private bool CanRunGersify()
+        {
+            return !IsRunning &&
+                   SelectedInputLayer?.Layer != null &&
+                   !string.IsNullOrWhiteSpace(SelectedIdField) &&
+                   !string.IsNullOrWhiteSpace(SelectedNameField) &&
+                   !string.IsNullOrWhiteSpace(OutputFolder);
+        }
+
+        private bool CanRunTraceSources()
+        {
+            return !IsRunning &&
+                   SelectedTraceLayer?.Layer != null &&
+                   !string.IsNullOrWhiteSpace(SelectedTraceGersIdField) &&
+                   !string.IsNullOrWhiteSpace(OutputFolder) &&
+                   !string.IsNullOrWhiteSpace(BridgeRoot) &&
+                   !string.IsNullOrWhiteSpace(BridgeRelease);
+        }
+
+        private void BrowseReleaseFolder()
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                Description = "Select Overture release folder",
+                UseDescriptionForTitle = true
+            };
+            if (!string.IsNullOrWhiteSpace(ReleaseFolderPath) && Directory.Exists(ReleaseFolderPath))
+                dialog.SelectedPath = ReleaseFolderPath;
+
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                ReleaseFolderPath = dialog.SelectedPath;
+            }
+        }
+
+        private void BrowseOutputFolder()
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                Description = "Select GERSify output folder",
+                UseDescriptionForTitle = true
+            };
+            if (!string.IsNullOrWhiteSpace(OutputFolder) && Directory.Exists(OutputFolder))
+                dialog.SelectedPath = OutputFolder;
+
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                OutputFolder = dialog.SelectedPath;
+            }
+        }
+
+        private string ResolveReleaseFolder()
+        {
+            if (!string.IsNullOrWhiteSpace(ReleaseFolderPath))
+                return ReleaseFolderPath;
+
+            ReleaseFolderPath = ProjectDataLocator.GetNewestLoadedReleaseFolder();
+            return ReleaseFolderPath;
+        }
+
+        private void RaiseCommandStatesChanged()
+        {
+            (RefreshLayersCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (BrowseReleaseFolderCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (BrowseOutputFolderCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (RunGersifyCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (RunTraceSourcesCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+
+        private void AddToLog(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+                return;
+
+            if (_logBuilder.Length > 0)
+                _logBuilder.AppendLine();
+            _logBuilder.Append(message);
+            LogText = _logBuilder.ToString();
+            System.Diagnostics.Debug.WriteLine(message);
+        }
+
+        private void ClearLog()
+        {
+            _logBuilder.Clear();
+            LogText = string.Empty;
+        }
+
+        private static string SelectField(IEnumerable<string> fields, params string[] candidates)
+        {
+            var fieldList = fields?.ToList() ?? [];
+            foreach (string candidate in candidates)
+            {
+                string match = fieldList.FirstOrDefault(field =>
+                    string.Equals(NormalizeFieldName(field), NormalizeFieldName(candidate), StringComparison.OrdinalIgnoreCase));
+                if (!string.IsNullOrWhiteSpace(match))
+                    return match;
+            }
+
+            return null;
+        }
+
+        private static string NormalizeFieldName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            var sb = new StringBuilder(value.Length);
+            foreach (char ch in value)
+            {
+                if (char.IsLetterOrDigit(ch))
+                    sb.Append(char.ToLowerInvariant(ch));
+            }
+            return sb.ToString();
+        }
+
+        private static string GetRowValue(Row row, string fieldName)
+        {
+            if (row == null || string.IsNullOrWhiteSpace(fieldName))
+                return string.Empty;
+
+            try
+            {
+                object value = row[fieldName];
+                return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string Csv(string value)
+        {
+            value ??= string.Empty;
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+
+        private static double ParseDouble(string value, double fallback)
+        {
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
+                ? parsed
+                : fallback;
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+                    File.Delete(path);
+            }
+            catch
+            {
+                // Temp file cleanup is best effort.
+            }
+        }
+
+        private sealed record GersifyInputExport(string CsvPath, int FeatureCount, ExtentBounds Extent);
+    }
+
+    public sealed class LayerSelectionItem
+    {
+        public LayerSelectionItem(string name, FeatureLayer layer)
+        {
+            Name = name;
+            Layer = layer;
+        }
+
+        public string Name { get; }
+        public FeatureLayer Layer { get; }
+    }
+}

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -31,6 +31,13 @@ namespace DuckDBGeoparquet.Views
         private string _selectedIdField;
         private string _selectedNameField;
         private string _selectedAddressField;
+        private string _selectedStreetNumberField;
+        private string _selectedStreetFractionField;
+        private string _selectedStreetPrefixField;
+        private string _selectedStreetNameField;
+        private string _selectedStreetTypeField;
+        private string _selectedStreetSuffixField;
+        private string _selectedUnitField;
         private string _selectedCityField;
         private string _selectedStateField;
         private string _selectedPostcodeField;
@@ -136,25 +143,111 @@ namespace DuckDBGeoparquet.Views
         public string SelectedAddressField
         {
             get => _selectedAddressField;
-            set => SetProperty(ref _selectedAddressField, value);
+            set
+            {
+                if (SetProperty(ref _selectedAddressField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedStreetNumberField
+        {
+            get => _selectedStreetNumberField;
+            set
+            {
+                if (SetProperty(ref _selectedStreetNumberField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedStreetFractionField
+        {
+            get => _selectedStreetFractionField;
+            set
+            {
+                if (SetProperty(ref _selectedStreetFractionField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedStreetPrefixField
+        {
+            get => _selectedStreetPrefixField;
+            set
+            {
+                if (SetProperty(ref _selectedStreetPrefixField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedStreetNameField
+        {
+            get => _selectedStreetNameField;
+            set
+            {
+                if (SetProperty(ref _selectedStreetNameField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedStreetTypeField
+        {
+            get => _selectedStreetTypeField;
+            set
+            {
+                if (SetProperty(ref _selectedStreetTypeField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedStreetSuffixField
+        {
+            get => _selectedStreetSuffixField;
+            set
+            {
+                if (SetProperty(ref _selectedStreetSuffixField, value))
+                    RaiseCommandStatesChanged();
+            }
+        }
+
+        public string SelectedUnitField
+        {
+            get => _selectedUnitField;
+            set
+            {
+                if (SetProperty(ref _selectedUnitField, value))
+                    RaiseCommandStatesChanged();
+            }
         }
 
         public string SelectedCityField
         {
             get => _selectedCityField;
-            set => SetProperty(ref _selectedCityField, value);
+            set
+            {
+                if (SetProperty(ref _selectedCityField, value))
+                    RaiseCommandStatesChanged();
+            }
         }
 
         public string SelectedStateField
         {
             get => _selectedStateField;
-            set => SetProperty(ref _selectedStateField, value);
+            set
+            {
+                if (SetProperty(ref _selectedStateField, value))
+                    RaiseCommandStatesChanged();
+            }
         }
 
         public string SelectedPostcodeField
         {
             get => _selectedPostcodeField;
-            set => SetProperty(ref _selectedPostcodeField, value);
+            set
+            {
+                if (SetProperty(ref _selectedPostcodeField, value))
+                    RaiseCommandStatesChanged();
+            }
         }
 
         public string SelectedTraceGersIdField
@@ -320,9 +413,16 @@ namespace DuckDBGeoparquet.Views
             SelectedIdField = SelectField(fields, "id", "record_id", "objectid", "fid", "globalid") ?? fields.FirstOrDefault();
             SelectedNameField = SelectField(fields, "name", "business_name", "poi_name", "label", "title");
             SelectedAddressField = SelectField(fields, "address", "full_address", "street_address", "addr", "situs");
-            SelectedCityField = SelectField(fields, "city", "locality", "town");
-            SelectedStateField = SelectField(fields, "state", "region", "province");
-            SelectedPostcodeField = SelectField(fields, "postcode", "postal_code", "zip", "zip5");
+            SelectedStreetNumberField = SelectField(fields, "address_number", "house_number", "housenumber", "addrnum", "saddno", "number");
+            SelectedStreetFractionField = SelectField(fields, "address_fraction", "fraction", "saddfrac");
+            SelectedStreetPrefixField = SelectField(fields, "address_prefix", "street_prefix", "predir", "saddpref", "prefix");
+            SelectedStreetNameField = SelectField(fields, "address_street", "street_name", "street", "road", "saddstr", "streetname");
+            SelectedStreetTypeField = SelectField(fields, "address_type", "street_type", "sttype", "saddsttyp");
+            SelectedStreetSuffixField = SelectField(fields, "address_suffix", "street_suffix", "postdir", "saddstsuf", "suffix");
+            SelectedUnitField = SelectField(fields, "address_unit", "unit", "apt", "apartment", "suite", "sunit");
+            SelectedCityField = SelectField(fields, "address_zipcity", "city", "locality", "town", "scity");
+            SelectedStateField = SelectField(fields, "address_state", "state", "region", "province", "state2");
+            SelectedPostcodeField = SelectField(fields, "address_zip5", "postcode", "postal_code", "zip", "zip5", "address_zip4");
         }
 
         private async Task RefreshTraceFieldsAsync(LayerSelectionItem layerItem)
@@ -376,6 +476,13 @@ namespace DuckDBGeoparquet.Views
                     SelectedIdField,
                     SelectedNameField,
                     SelectedAddressField,
+                    SelectedStreetNumberField,
+                    SelectedStreetFractionField,
+                    SelectedStreetPrefixField,
+                    SelectedStreetNameField,
+                    SelectedStreetTypeField,
+                    SelectedStreetSuffixField,
+                    SelectedUnitField,
                     SelectedCityField,
                     SelectedStateField,
                     SelectedPostcodeField);
@@ -396,6 +503,13 @@ namespace DuckDBGeoparquet.Views
                     UniqueIdField = SelectedIdField,
                     NameField = SelectedNameField,
                     AddressField = SelectedAddressField,
+                    StreetNumberField = SelectedStreetNumberField,
+                    StreetFractionField = SelectedStreetFractionField,
+                    StreetPrefixField = SelectedStreetPrefixField,
+                    StreetNameField = SelectedStreetNameField,
+                    StreetTypeField = SelectedStreetTypeField,
+                    StreetSuffixField = SelectedStreetSuffixField,
+                    UnitField = SelectedUnitField,
                     CityField = SelectedCityField,
                     StateField = SelectedStateField,
                     PostcodeField = SelectedPostcodeField,
@@ -482,6 +596,13 @@ namespace DuckDBGeoparquet.Views
             string idField,
             string nameField,
             string addressField,
+            string streetNumberField,
+            string streetFractionField,
+            string streetPrefixField,
+            string streetNameField,
+            string streetTypeField,
+            string streetSuffixField,
+            string unitField,
             string cityField,
             string stateField,
             string postcodeField)
@@ -532,7 +653,7 @@ namespace DuckDBGeoparquet.Views
                     sb.AppendLine(string.Join(",",
                         Csv(recordId),
                         Csv(GetRowValue(row, nameField)),
-                        Csv(GetRowValue(row, addressField)),
+                        Csv(BuildAddressValue(row, addressField, streetNumberField, streetFractionField, streetPrefixField, streetNameField, streetTypeField, streetSuffixField, unitField)),
                         Csv(GetRowValue(row, cityField)),
                         Csv(GetRowValue(row, stateField)),
                         Csv(GetRowValue(row, postcodeField)),
@@ -681,8 +802,15 @@ namespace DuckDBGeoparquet.Views
             return !IsRunning &&
                    SelectedInputLayer?.Layer != null &&
                    !string.IsNullOrWhiteSpace(SelectedIdField) &&
-                   !string.IsNullOrWhiteSpace(SelectedNameField) &&
+                   HasAnyGersifyMatchField() &&
                    !string.IsNullOrWhiteSpace(OutputFolder);
+        }
+
+        private bool HasAnyGersifyMatchField()
+        {
+            return !string.IsNullOrWhiteSpace(SelectedNameField) ||
+                   !string.IsNullOrWhiteSpace(SelectedAddressField) ||
+                   !string.IsNullOrWhiteSpace(SelectedStreetNameField);
         }
 
         private bool CanRunTraceSources()
@@ -805,6 +933,44 @@ namespace DuckDBGeoparquet.Views
             {
                 return string.Empty;
             }
+        }
+
+        private static string BuildAddressValue(
+            Row row,
+            string addressField,
+            string streetNumberField,
+            string streetFractionField,
+            string streetPrefixField,
+            string streetNameField,
+            string streetTypeField,
+            string streetSuffixField,
+            string unitField)
+        {
+            string fullAddress = CleanPart(GetRowValue(row, addressField));
+            if (!string.IsNullOrWhiteSpace(fullAddress))
+                return fullAddress;
+
+            return string.Join(" ", new[]
+                {
+                    CleanPart(GetRowValue(row, streetNumberField)),
+                    CleanPart(GetRowValue(row, streetFractionField)),
+                    CleanPart(GetRowValue(row, streetPrefixField)),
+                    CleanPart(GetRowValue(row, streetNameField)),
+                    CleanPart(GetRowValue(row, streetTypeField)),
+                    CleanPart(GetRowValue(row, streetSuffixField)),
+                    CleanPart(GetRowValue(row, unitField))
+                }
+                .Where(part => !string.IsNullOrWhiteSpace(part)));
+        }
+
+        private static string CleanPart(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            return string.Join(" ",
+                value.Trim().Trim('"')
+                    .Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
         }
 
         private static string Csv(string value)

--- a/Views/GersifyDockpaneViewModel.cs
+++ b/Views/GersifyDockpaneViewModel.cs
@@ -531,6 +531,11 @@ namespace DuckDBGeoparquet.Views
 
                 StatusText = $"Matched {result.AcceptedCount:N0} of {result.InputCount:N0} feature(s); reviewed {result.CandidateCount:N0} candidate(s).";
                 AddToLog($"Input text coverage: {result.InputNameCount:N0} with names; {result.InputAddressCount:N0} with addresses.");
+                AddToLog($"Overture candidate address coverage: {result.CandidateOvertureAddressCount:N0} with address text; {result.CandidateAddressSimilarityCount:N0} with address similarity scores.");
+                if (result.CandidateCount > 0 && result.CandidateAddressSimilarityCount == 0)
+                {
+                    AddToLog("No address similarity scores were produced. The selected Overture Places files likely do not include flattened place address fields; re-download Places with this add-in version to enable address-based GERSify scoring.");
+                }
                 AddToLog($"Candidates reviewed: {result.CandidateCount:N0}; accepted matches: {result.AcceptedCount:N0}.");
                 AddToLog($"Output feature class: {result.OutputFeatureClassPath}");
                 AddToLog($"Candidate review CSV: {result.CandidateCsvPath}");

--- a/Views/GersifyShowButton.cs
+++ b/Views/GersifyShowButton.cs
@@ -1,0 +1,30 @@
+using ArcGIS.Desktop.Framework.Contracts;
+using System;
+
+namespace DuckDBGeoparquet.Views
+{
+    internal class GersifyShowButton : Button
+    {
+        protected override void OnClick()
+        {
+            try
+            {
+                GersifyDockpaneViewModel.Show();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error opening GERSify Data: {ex.Message}");
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(
+                    "Unable to open GERSify Data. See ArcGIS Pro logs for details.",
+                    "GERSify Data",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+
+        protected override void OnUpdate()
+        {
+            Enabled = true;
+        }
+    }
+}

--- a/Views/MfcDockpaneViewModel.cs
+++ b/Views/MfcDockpaneViewModel.cs
@@ -14,7 +14,7 @@ namespace DuckDBGeoparquet.Views
 {
     internal class MfcDockpaneViewModel : DockPane
     {
-        private const string _dockPaneID = "DuckDBGeoparquet_Views_MfcDockpane";
+        private const string _dockPaneID = "DuckDBGeoparquet_Views_MfcDockpane_V2";
         private const string DefaultMfcFileName = "OvertureData.mfc";
         private const string AddExistingMfcCommandId = "esri_bdc_addExistingBDConnectionButton";
 

--- a/Views/OvertureGeocoderDockpaneViewModel.cs
+++ b/Views/OvertureGeocoderDockpaneViewModel.cs
@@ -21,7 +21,7 @@ namespace DuckDBGeoparquet.Views
 {
     internal class OvertureGeocoderDockpaneViewModel : DockPane
     {
-        private const string DockPaneId = "DuckDBGeoparquet_Views_OvertureGeocoderDockpane";
+        private const string DockPaneId = "DuckDBGeoparquet_Views_OvertureGeocoderDockpane_V2";
         private OvertureGeocoderService _geocoderService;
         private readonly List<IDisposable> _candidateOverlays = [];
         private readonly List<IDisposable> _selectionOverlays = [];

--- a/Views/WizardDockpaneViewModel.cs
+++ b/Views/WizardDockpaneViewModel.cs
@@ -32,7 +32,7 @@ namespace DuckDBGeoparquet.Views
 {
     internal partial class WizardDockpaneViewModel : DockPane
     {
-        private const string _dockPaneID = "DuckDBGeoparquet_Views_WizardDockpane";
+        private const string _dockPaneID = "DuckDBGeoparquet_Views_WizardDockpane_V2";
         private DataProcessor _dataProcessor;
         private const string RELEASE_URL = "https://labs.overturemaps.org/data/releases.json";
         private const string S3_BASE_PATH = "s3://overturemaps-us-west-2/release";


### PR DESCRIPTION
## Summary
- Add a GERSify field mapping preview panel that shows resolved source fields and sample built address/postcode values before long runs.
- Warn about suspicious mappings such as non-numeric postcode samples, missed street direction fields, and unit/subaddress records.
- Avoid noisy ArcGIS first-chance field exceptions by checking known postcode fallback fields before reading row values.

## Validation
- Built and deployed with Visual Studio 2026 MSBuild:
  `& 'C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe' DuckDBGeoparquet.csproj /restore:false /verbosity:minimal`
- Ran tests:
  `dotnet test DuckDBGeoparquet.Tests/DuckDBGeoparquet.Tests.csproj --no-build -v minimal`
- Validated in ArcGIS Pro against Fresno `geoprod.REGIONAL_VIEWS.ADDRESS`:
  - postcode output contains ZIP values, not street types
  - unit/subaddress sample `1235 N RECREATION AVE 204` matched base Overture address as `address`, not `exact_address`
  - accepted 298,144 matches, including 206,785 `exact_address` and 91,359 `address`
